### PR TITLE
[Visual Studio] header files with exclude tag and remove from project if all configurations ignore it

### DIFF
--- a/Sharpmake.Generators/VisualStudio/Vcxproj.Template.cs
+++ b/Sharpmake.Generators/VisualStudio/Vcxproj.Template.cs
@@ -222,6 +222,14 @@ namespace Sharpmake.Generators.VisualStudio
                 @"    <ClInclude Include=""[file.FileNameProjectRelative]"" />
 ";
 
+                public static string ProjectFilesHeaderBegin =
+                @"    <ClInclude Include=""[file.FileNameProjectRelative]"" >
+";
+
+                public static string ProjectFilesHeaderEnd =
+                @"    </ClInclude>
+";
+
                 public static string ProjectFilesNatvis =
                 @"    <Natvis Include=""[file.FileNameProjectRelative]"" />
 ";

--- a/Sharpmake.Generators/VisualStudio/Vcxproj.cs
+++ b/Sharpmake.Generators/VisualStudio/Vcxproj.cs
@@ -1245,6 +1245,21 @@ namespace Sharpmake.Generators.VisualStudio
             var customSourceFiles = new Dictionary<string, List<ProjectFile>>();
             foreach (ProjectFile projectFile in allFiles)
             {
+                //First check if this projectFile is present in any of the configuration, if excluded from all, don't add it
+                bool addFile = false;
+                foreach (Project.Configuration conf in context.ProjectConfigurations)
+                {
+                    if (conf.ResolvedSourceFilesBuildExclude.Contains(projectFile.FileName) == false)
+                    {
+                        addFile = true;
+                        break;
+                    }
+                }
+                if (addFile == false)
+                {
+                    continue;
+                }
+
                 string type = null;
                 if (context.Project.ExtensionBuildTools.TryGetValue(projectFile.FileExtension, out type))
                 {

--- a/Sharpmake.Generators/VisualStudio/Vcxproj.cs
+++ b/Sharpmake.Generators/VisualStudio/Vcxproj.cs
@@ -1312,8 +1312,38 @@ namespace Sharpmake.Generators.VisualStudio
             {
                 foreach (ProjectFile file in includeFiles)
                 {
+                    bool writeEnd = false;
                     using (fileGenerator.Declare("file", file))
-                        fileGenerator.Write(Template.Project.ProjectFilesHeader);
+                    {
+                        foreach (Project.Configuration conf in context.ProjectConfigurations)
+                        {
+                            using (fileGenerator.Declare("conf", conf))
+                            using (fileGenerator.Declare("platformName", Util.GetPlatformString(conf.Platform, conf.Project)))
+                            {
+                                bool isExcludeFromBuild = conf.ResolvedSourceFilesBuildExclude.Contains(file.FileName);
+                                if (isExcludeFromBuild)
+                                {
+                                    if (writeEnd == false)
+                                    {
+                                        fileGenerator.Write(Template.Project.ProjectFilesHeaderBegin);
+                                        writeEnd = true;
+                                    }
+                                    fileGenerator.Write(Template.Project.ProjectFilesSourceExcludeFromBuild);
+                                }
+
+                            }
+                        }
+
+                        if (writeEnd)
+                        {
+                            fileGenerator.Write(Template.Project.ProjectFilesHeaderEnd);
+                        }
+                        else
+                        {
+                            fileGenerator.Write(Template.Project.ProjectFilesHeader);
+                        }
+                    }
+
                 }
             }
             fileGenerator.Write(Template.Project.ProjectFilesEnd);

--- a/Sharpmake.Generators/VisualStudio/Vcxproj.cs
+++ b/Sharpmake.Generators/VisualStudio/Vcxproj.cs
@@ -1249,7 +1249,7 @@ namespace Sharpmake.Generators.VisualStudio
                 bool addFile = false;
                 foreach (Project.Configuration conf in context.ProjectConfigurations)
                 {
-                    if (conf.ResolvedSourceFilesBuildExclude.Contains(projectFile.FileName) == false)
+                    if (conf.ResolvedSourceFilesExclude.Contains(projectFile.FileName) == false)
                     {
                         addFile = true;
                         break;

--- a/Sharpmake/Project.Configuration.cs
+++ b/Sharpmake/Project.Configuration.cs
@@ -304,6 +304,14 @@ namespace Sharpmake
             public Strings SourceFilesFiltersRegex = new Strings();
 
             /// <summary>
+            /// Excluded file from project for this configuration
+            /// </summary>
+            public Strings SourceFilesExclude = new Strings();
+
+            public Strings SourceFilesExcludeRegex = new Strings();
+            
+
+            /// <summary>
             /// Sources file that match this regex will be compiled as C Files
             /// </summary>
             public Strings SourceFilesCompileAsCRegex = new Strings();
@@ -1044,6 +1052,8 @@ namespace Sharpmake
             }
 
             public Strings ResolvedSourceFilesBuildExclude = new Strings();
+
+            public Strings ResolvedSourceFilesExclude = new Strings();
 
             public Strings ResolvedSourceFilesBlobExclude = new Strings();
 

--- a/Sharpmake/Project.cs
+++ b/Sharpmake/Project.cs
@@ -814,7 +814,22 @@ namespace Sharpmake
                 if (conf.IsFastBuild && conf.FastBuildBlobbed)
                     fastBuildBlobs = true;
 
+                var confSourceFilesExcludeRegex = RegexCache.GetCachedRegexes(conf.SourceFilesExcludeRegex);
+
+                // Remove file that match conf.SourceFilesExcludeRegex
+                if (AddMatchFiles(RootPath, Util.PathGetRelative(RootPath, SourceFiles), SourceFiles, ref conf.SourceFilesExclude, confSourceFilesExcludeRegex))
+                    System.Diagnostics.Debugger.Break();
+                if (AddMatchFiles(RootPath, Util.PathGetRelative(RootPath, ResourceFiles), ResourceFiles, ref conf.SourceFilesExclude, confSourceFilesExcludeRegex))
+                    System.Diagnostics.Debugger.Break();
+                if (AddMatchFiles(RootPath, Util.PathGetRelative(RootPath, NatvisFiles), NatvisFiles, ref conf.SourceFilesExclude, confSourceFilesExcludeRegex))
+                    System.Diagnostics.Debugger.Break();
+
                 conf.ResolvedSourceFilesBuildExclude.AddRange(SourceFilesExclude);
+
+                //Add SourceFilesExclude also to ResolvedSourceFilesBuildExclude in case we end up needing file for
+                //another configuration that way it gets added but excluded from build in this config
+                conf.ResolvedSourceFilesBuildExclude.AddRange(conf.SourceFilesExclude);
+                conf.ResolvedSourceFilesExclude.AddRange(conf.SourceFilesExclude);
 
                 // add SourceFilesBuildExclude from the project
                 if (DebugBreaks.ShouldBreakOnSourcePath(DebugBreaks.Context.Resolving, ResolvedSourceFilesBuildExclude))
@@ -939,6 +954,7 @@ namespace Sharpmake
                             conf.ResolvedSourceFilesBuildExclude.Add(sourceFile);
                     }
                     Util.ResolvePath(SourceRootPath, ref conf.ResolvedSourceFilesBuildExclude);
+                    Util.ResolvePath(SourceRootPath, ref conf.ResolvedSourceFilesExclude);
                 }
             }
 

--- a/samples/QTFileCustomBuild/reference/projects/qtfilecustombuild_vs2017_win64.vcxproj
+++ b/samples/QTFileCustomBuild/reference/projects/qtfilecustombuild_vs2017_win64.vcxproj
@@ -486,13 +486,43 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="obj\win64\qt\debug\moc_floatcosanglespinbox.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="obj\win64\qt\debug\moc_privatewidget.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="obj\win64\qt\release\moc_floatanglespinbox.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="obj\win64\qt\release\moc_floatcosanglespinbox.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="obj\win64\qt\release\moc_privatewidget.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="obj\win64\qt\retail\moc_floatanglespinbox.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="obj\win64\qt\retail\moc_floatcosanglespinbox.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="obj\win64\qt\retail\moc_privatewidget.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">true</ExcludedFromBuild>
     </ClCompile>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/samples/QTFileCustomBuild/reference/projects/qtfilecustombuild_vs2017_win64.vcxproj
+++ b/samples/QTFileCustomBuild/reference/projects/qtfilecustombuild_vs2017_win64.vcxproj
@@ -373,9 +373,18 @@
   <ItemGroup>
     <ClInclude Include="..\codebase\stdafx.h" />
     <ClInclude Include="obj\qtfilecustombuild\qt\ui_privatewidget.h" />
-    <ClInclude Include="obj\win64\qt\debug\privatewidget.moc" />
-    <ClInclude Include="obj\win64\qt\release\privatewidget.moc" />
-    <ClInclude Include="obj\win64\qt\retail\privatewidget.moc" />
+    <ClInclude Include="obj\win64\qt\debug\privatewidget.moc" >
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="obj\win64\qt\release\privatewidget.moc" >
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="obj\win64\qt\retail\privatewidget.moc" >
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="..\codebase\exec.qrc">
@@ -477,43 +486,13 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="obj\win64\qt\debug\moc_floatcosanglespinbox.cpp">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="obj\win64\qt\debug\moc_privatewidget.cpp">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">true</ExcludedFromBuild>
-    </ClCompile>
     <ClCompile Include="obj\win64\qt\release\moc_floatanglespinbox.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="obj\win64\qt\release\moc_floatcosanglespinbox.cpp">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="obj\win64\qt\release\moc_privatewidget.cpp">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="obj\win64\qt\retail\moc_floatanglespinbox.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="obj\win64\qt\retail\moc_floatcosanglespinbox.cpp">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="obj\win64\qt\retail\moc_privatewidget.cpp">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">true</ExcludedFromBuild>
     </ClCompile>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/samples/QTFileCustomBuild/reference/projects/qtfilecustombuild_vs2017_win64.vcxproj.filters
+++ b/samples/QTFileCustomBuild/reference/projects/qtfilecustombuild_vs2017_win64.vcxproj.filters
@@ -11,10 +11,28 @@
     <ClCompile Include="obj\win64\qt\debug\moc_floatanglespinbox.cpp">
       <Filter>projects\obj\win64\qt\debug</Filter>
     </ClCompile>
+    <ClCompile Include="obj\win64\qt\debug\moc_floatcosanglespinbox.cpp">
+      <Filter>projects\obj\win64\qt\debug</Filter>
+    </ClCompile>
+    <ClCompile Include="obj\win64\qt\debug\moc_privatewidget.cpp">
+      <Filter>projects\obj\win64\qt\debug</Filter>
+    </ClCompile>
     <ClCompile Include="obj\win64\qt\release\moc_floatanglespinbox.cpp">
       <Filter>projects\obj\win64\qt\release</Filter>
     </ClCompile>
+    <ClCompile Include="obj\win64\qt\release\moc_floatcosanglespinbox.cpp">
+      <Filter>projects\obj\win64\qt\release</Filter>
+    </ClCompile>
+    <ClCompile Include="obj\win64\qt\release\moc_privatewidget.cpp">
+      <Filter>projects\obj\win64\qt\release</Filter>
+    </ClCompile>
     <ClCompile Include="obj\win64\qt\retail\moc_floatanglespinbox.cpp">
+      <Filter>projects\obj\win64\qt\retail</Filter>
+    </ClCompile>
+    <ClCompile Include="obj\win64\qt\retail\moc_floatcosanglespinbox.cpp">
+      <Filter>projects\obj\win64\qt\retail</Filter>
+    </ClCompile>
+    <ClCompile Include="obj\win64\qt\retail\moc_privatewidget.cpp">
       <Filter>projects\obj\win64\qt\retail</Filter>
     </ClCompile>
   </ItemGroup>

--- a/samples/QTFileCustomBuild/reference/projects/qtfilecustombuild_vs2017_win64.vcxproj.filters
+++ b/samples/QTFileCustomBuild/reference/projects/qtfilecustombuild_vs2017_win64.vcxproj.filters
@@ -11,28 +11,10 @@
     <ClCompile Include="obj\win64\qt\debug\moc_floatanglespinbox.cpp">
       <Filter>projects\obj\win64\qt\debug</Filter>
     </ClCompile>
-    <ClCompile Include="obj\win64\qt\debug\moc_floatcosanglespinbox.cpp">
-      <Filter>projects\obj\win64\qt\debug</Filter>
-    </ClCompile>
-    <ClCompile Include="obj\win64\qt\debug\moc_privatewidget.cpp">
-      <Filter>projects\obj\win64\qt\debug</Filter>
-    </ClCompile>
     <ClCompile Include="obj\win64\qt\release\moc_floatanglespinbox.cpp">
       <Filter>projects\obj\win64\qt\release</Filter>
     </ClCompile>
-    <ClCompile Include="obj\win64\qt\release\moc_floatcosanglespinbox.cpp">
-      <Filter>projects\obj\win64\qt\release</Filter>
-    </ClCompile>
-    <ClCompile Include="obj\win64\qt\release\moc_privatewidget.cpp">
-      <Filter>projects\obj\win64\qt\release</Filter>
-    </ClCompile>
     <ClCompile Include="obj\win64\qt\retail\moc_floatanglespinbox.cpp">
-      <Filter>projects\obj\win64\qt\retail</Filter>
-    </ClCompile>
-    <ClCompile Include="obj\win64\qt\retail\moc_floatcosanglespinbox.cpp">
-      <Filter>projects\obj\win64\qt\retail</Filter>
-    </ClCompile>
-    <ClCompile Include="obj\win64\qt\retail\moc_privatewidget.cpp">
       <Filter>projects\obj\win64\qt\retail</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
Hello,

This refers to a issue I opened a couple months ago https://github.com/ubisoftinc/Sharpmake/issues/33

I made some changes so that Include files (.h etc) that match exclude from build regex also get the Template.Project.ProjectFilesSourceExcludeFromBuild tag, previously it was only .cpp files. I know having the .h be part of the build or not doesn't impact the configuration but I think this makes it easier to see the solution tree, now both .h and .cpp will show as not part of build.

Another change I made is that while looping allFiles and deciding if a source or header, if all requested Project configurations happen to exclude a certain file then it doesn't get added at all. So in case someone builds only a win32 project it would exclude all mac files for example. But if they add both to configuration it adds the files but marks as ignore from build.

Let me know thoughts and suggestions, if this is helpful or not. 
