### PR TITLE
Fix library dependency copy

### DIFF
--- a/Sharpmake.Generators/FastBuild/Bff.cs
+++ b/Sharpmake.Generators/FastBuild/Bff.cs
@@ -1598,7 +1598,9 @@ namespace Sharpmake.Generators.FastBuild
             string platformOutputLibraryExtension = string.Empty;
             string platformPrefix = string.Empty;
             platformVcxproj.SetupPlatformLibraryOptions(ref platformLibraryExtension, ref platformOutputLibraryExtension, ref platformPrefix);
-            string libPrefix = platformVcxproj.GetOutputFileNamePrefix(context, Project.Configuration.OutputType.Lib);
+
+            var configurationTasks = PlatformRegistry.Query<Project.Configuration.IConfigurationTasks>(context.Configuration.Platform);
+            string libPrefix = configurationTasks.GetOutputFileNamePrefix(Project.Configuration.OutputType.Lib);
 
             var additionalDependencies = new OrderableStrings();
 

--- a/Sharpmake.Generators/VisualStudio/IPlatformVcxproj.cs
+++ b/Sharpmake.Generators/VisualStudio/IPlatformVcxproj.cs
@@ -59,8 +59,6 @@ namespace Sharpmake.Generators.VisualStudio
 
         IEnumerable<VariableAssignment> GetEnvironmentVariables(IGenerationContext context);
 
-        string GetOutputFileNamePrefix(IGenerationContext context, Project.Configuration.OutputType outputType);
-
         void SetupDeleteExtensionsOnCleanOptions(IGenerationContext context);
         void SetupSdkOptions(IGenerationContext context);
         void SetupPlatformToolsetOptions(IGenerationContext context);

--- a/Sharpmake.Generators/VisualStudio/ProjectOptionsGenerator.cs
+++ b/Sharpmake.Generators/VisualStudio/ProjectOptionsGenerator.cs
@@ -1217,7 +1217,9 @@ namespace Sharpmake.Generators.VisualStudio
             if (outputExtension.Length > 0 && !outputExtension.StartsWith(".", StringComparison.Ordinal))
                 outputExtension = outputExtension.Insert(0, ".");
 
-            string outputFileName = optionsContext.PlatformVcxproj.GetOutputFileNamePrefix(context, context.Configuration.Output) + optionsContext.TargetName;
+            var configurationTasks = PlatformRegistry.Get<Project.Configuration.IConfigurationTasks>(context.Configuration.Platform);
+            string outputPrefixPrefix = configurationTasks.GetOutputFileNamePrefix(context.Configuration.Output);
+            string outputFileName = outputPrefixPrefix + optionsContext.TargetName;
 
             context.Options["ImportLibrary"] = FileGeneratorUtilities.RemoveLineTag;
             context.CommandLineOptions["ImportLibrary"] = FileGeneratorUtilities.RemoveLineTag;
@@ -2234,8 +2236,11 @@ namespace Sharpmake.Generators.VisualStudio
             Action enableMapOption = () =>
             {
                 context.Options["GenerateMapFile"] = "true";
-                string targetNamePrefix = optionsContext.PlatformVcxproj.GetOutputFileNamePrefix(context, context.Configuration.Output);
-                string mapFile = Path.Combine(optionsContext.OutputDirectoryRelative, targetNamePrefix + optionsContext.TargetName + ".map");
+
+                var configurationTasks = PlatformRegistry.Get<Project.Configuration.IConfigurationTasks>(context.Configuration.Platform);
+                string outputPrefixPrefix = configurationTasks.GetOutputFileNamePrefix(context.Configuration.Output);
+                string outputFileName = outputPrefixPrefix + optionsContext.TargetName + ".map";
+                string mapFile = Path.Combine(optionsContext.OutputDirectoryRelative, outputFileName);
                 context.Options["MapFileName"] = mapFile;
 
                 string mapFileBffRelative = FormatCommandLineOptionPath(context, mapFile);

--- a/Sharpmake.Generators/VisualStudio/Vcxproj.cs
+++ b/Sharpmake.Generators/VisualStudio/Vcxproj.cs
@@ -797,7 +797,8 @@ namespace Sharpmake.Generators.VisualStudio
                     libraryFiles[i] = Util.GetConvertedRelativePath(context.ProjectDirectory, libraryFile, context.ProjectDirectory, true, context.Project.RootPath);
             }
 
-            string libPrefix = platformVcxproj.GetOutputFileNamePrefix(context, Project.Configuration.OutputType.Lib);
+            var configurationTasks = PlatformRegistry.Get<Project.Configuration.IConfigurationTasks>(context.Configuration.Platform);
+            string libPrefix = configurationTasks.GetOutputFileNamePrefix(Project.Configuration.OutputType.Lib);
 
             var additionalDependencies = new Strings();
             foreach (string libraryFile in libraryFiles)

--- a/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Android/AndroidPlatform.cs
+++ b/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Android/AndroidPlatform.cs
@@ -87,6 +87,13 @@ namespace Sharpmake
                 }
             }
 
+            public string GetOutputFileNamePrefix(Project.Configuration.OutputType outputType)
+            {
+                if (outputType != Project.Configuration.OutputType.Exe)
+                    return "lib";
+                return string.Empty;
+            }
+
             public IEnumerable<string> GetPlatformLibraryPaths(Project.Configuration configuration)
             {
                 yield break;
@@ -98,13 +105,6 @@ namespace Sharpmake
             public override string SharedLibraryFileExtension => "so";
             public override string StaticLibraryFileExtension => "a";
             public override string ExecutableFileExtension => string.Empty;
-
-            public override string GetOutputFileNamePrefix(IGenerationContext context, Project.Configuration.OutputType outputType)
-            {
-                if (outputType != Project.Configuration.OutputType.Exe)
-                    return "lib";
-                return string.Empty;
-            }
 
             public override void GeneratePlatformSpecificProjectDescription(IVcxprojGenerationContext context, IFileGenerator generator)
             {

--- a/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Apple/BaseApplePlatform.cs
+++ b/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Apple/BaseApplePlatform.cs
@@ -294,6 +294,11 @@ namespace Sharpmake
             }
         }
 
+        public string GetOutputFileNamePrefix(Project.Configuration.OutputType outputType)
+        {
+            return string.Empty;
+        }
+
         public IEnumerable<string> GetPlatformLibraryPaths(Project.Configuration configuration)
         {
             yield break;

--- a/Sharpmake.Platforms/Sharpmake.CommonPlatforms/BaseMicrosoftPlatform.cs
+++ b/Sharpmake.Platforms/Sharpmake.CommonPlatforms/BaseMicrosoftPlatform.cs
@@ -65,6 +65,11 @@ namespace Sharpmake
             }
         }
 
+        public string GetOutputFileNamePrefix(Project.Configuration.OutputType outputType)
+        {
+            return string.Empty;
+        }
+
         public virtual IEnumerable<string> GetPlatformLibraryPaths(Project.Configuration configuration)
         {
             var dirs = new List<string>();

--- a/Sharpmake.Platforms/Sharpmake.CommonPlatforms/BasePlatform.cs
+++ b/Sharpmake.Platforms/Sharpmake.CommonPlatforms/BasePlatform.cs
@@ -205,11 +205,6 @@ namespace Sharpmake
             yield break;
         }
 
-        public virtual string GetOutputFileNamePrefix(IGenerationContext context, Project.Configuration.OutputType outputType)
-        {
-            return string.Empty;
-        }
-
         public virtual void SetupSdkOptions(IGenerationContext context)
         {
         }

--- a/Sharpmake.Platforms/Sharpmake.CommonPlatforms/DefaultPlatform.cs
+++ b/Sharpmake.Platforms/Sharpmake.CommonPlatforms/DefaultPlatform.cs
@@ -84,6 +84,11 @@ namespace Sharpmake
             }
         }
 
+        public string GetOutputFileNamePrefix(Project.Configuration.OutputType outputType)
+        {
+            return string.Empty;
+        }
+
         public IEnumerable<string> GetPlatformLibraryPaths(Project.Configuration configuration)
         {
             yield break;

--- a/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Linux/LinuxPlatform.cs
+++ b/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Linux/LinuxPlatform.cs
@@ -62,6 +62,13 @@ namespace Sharpmake
                 }
             }
 
+            public string GetOutputFileNamePrefix(Project.Configuration.OutputType outputType)
+            {
+                if (outputType != Project.Configuration.OutputType.Exe)
+                    return "lib";
+                return string.Empty;
+            }
+
             public IEnumerable<string> GetPlatformLibraryPaths(Project.Configuration conf)
             {
                 if (GlobalSettings.SystemPathProvider != null)
@@ -90,13 +97,6 @@ namespace Sharpmake
             public override string ExecutableFileExtension => string.Empty;
 
             // Ideally the object files should be suffixed .o when compiling with FastBuild, using the CompilerOutputExtension property in ObjectLists
-
-            public override string GetOutputFileNamePrefix(IGenerationContext context, Project.Configuration.OutputType outputType)
-            {
-                if (outputType != Project.Configuration.OutputType.Exe)
-                    return "lib";
-                return string.Empty;
-            }
 
             public override void SetupPlatformToolsetOptions(IGenerationContext context)
             {

--- a/Sharpmake.Platforms/Sharpmake.NvShield/NvShieldPlatform.cs
+++ b/Sharpmake.Platforms/Sharpmake.NvShield/NvShieldPlatform.cs
@@ -48,6 +48,12 @@ namespace Sharpmake
                         return "a";
                 }
             }
+
+            public string GetOutputFileNamePrefix(Project.Configuration.OutputType outputType)
+            {
+                return "lib";
+            }
+
             public void SetupDynamicLibraryPaths(Project.Configuration configuration, DependencySetting dependencySetting, Project.Configuration dependency)
             {
                 DefaultPlatform.SetupLibraryPaths(configuration, dependencySetting, dependency);
@@ -70,11 +76,6 @@ namespace Sharpmake
             public override string ProgramDatabaseFileExtension => "so";
             public override string StaticLibraryFileExtension => string.Empty;
             public override string StaticOutputLibraryFileExtension => string.Empty;
-
-            public override string GetOutputFileNamePrefix(IGenerationContext context, Project.Configuration.OutputType outputType)
-            {
-                return "lib";
-            }
 
             public override void SelectCompilerOptions(IGenerationContext context)
             {


### PR DESCRIPTION
~~Dependent dlls were assumed to have the .dll extension.~~ I moved the library extension code from IPlatformVcxproj to IConfigurationTasks so I could use it with the default library prefix and get dependency copy working for .so files. This is probably an API break for anyone using non-standard platforms, should I leave the old function and just forward it?

This isn't a complete fix for android projects in visual studio though since this only copies the .so files local to your exe file (which is also compiled as a .so). They still need to be copied to the android package output/Package/libs/<architecture> so the package builder can pick them up. I haven't figured a good way to do that automatically. (architecture = arm64-v8a for ARM64)