### PR TITLE
Embed Interop references support and CSharp7_2

### DIFF
--- a/Sharpmake.Generators/VisualStudio/Csproj.cs
+++ b/Sharpmake.Generators/VisualStudio/Csproj.cs
@@ -2009,7 +2009,7 @@ namespace Sharpmake.Generators.VisualStudio
                         Include = Path.GetFileNameWithoutExtension(str),
                         SpecificVersion = false,
                         HintPath = Util.PathGetRelative(_projectPathCapitalized, str),
-                        Private = project.DependenciesCopyLocal.HasFlag(Project.DependenciesCopyLocalTypes.ExternalReferences),
+                        Private = project.DependenciesCopyLocal.HasFlag(Project.DependenciesCopyLocalTypes.ExternalReferences)
                     }));
 
                 referencesByPath.AddRange(
@@ -2021,6 +2021,16 @@ namespace Sharpmake.Generators.VisualStudio
                         HintPath = Util.PathGetRelative(_projectPathCapitalized, str),
                         Private = false
                     }));
+                referencesByPath.AddRange(
+                    conf.ReferencesByPathEmbedInterop.Select(Util.GetCapitalizedPath)
+                        .Select(str => new ItemGroups.Reference
+                        {
+                            Include = Path.GetFileNameWithoutExtension(str),
+                            SpecificVersion = false,
+                            HintPath = Util.PathGetRelative(_projectPathCapitalized, str),
+                            Private = project.DependenciesCopyLocal.HasFlag(Project.DependenciesCopyLocalTypes.ExternalReferences),
+                            EmbedInteropTypes = true
+                        }));
             }
 
             itemGroups.References.AddRange(referencesByPath);
@@ -2903,7 +2913,7 @@ namespace Sharpmake.Generators.VisualStudio
 
             SelectOption
             (
-            Options.Option(Options.CSharp.WarningLevel.Level0, () => { options["WarningLevel"] = "TurnOffAllWarnings"; }),
+            Options.Option(Options.CSharp.WarningLevel.Level0, () => { options["WarningLevel"] = "0"; }),
             Options.Option(Options.CSharp.WarningLevel.Level1, () => { options["WarningLevel"] = "1"; }),
             Options.Option(Options.CSharp.WarningLevel.Level2, () => { options["WarningLevel"] = "2"; }),
             Options.Option(Options.CSharp.WarningLevel.Level3, () => { options["WarningLevel"] = "3"; }),
@@ -2921,7 +2931,8 @@ namespace Sharpmake.Generators.VisualStudio
             Options.Option(Options.CSharp.LanguageVersion.CSharp5, () => { options["LanguageVersion"] = "5"; }),
             Options.Option(Options.CSharp.LanguageVersion.CSharp6, () => { options["LanguageVersion"] = "6"; }),
             Options.Option(Options.CSharp.LanguageVersion.CSharp7, () => { options["LanguageVersion"] = "7"; }),
-            Options.Option(Options.CSharp.LanguageVersion.CSharp7_1, () => { options["LanguageVersion"] = "7.1"; })
+            Options.Option(Options.CSharp.LanguageVersion.CSharp7_1, () => { options["LanguageVersion"] = "7.1"; }),
+            Options.Option(Options.CSharp.LanguageVersion.CSharp7_2, () => { options["LanguageVersion"] = "7.2"; })
             );
 
             SelectOption(

--- a/Sharpmake/AttributeParsers.cs
+++ b/Sharpmake/AttributeParsers.cs
@@ -68,6 +68,9 @@ namespace Sharpmake
                     throw new Error("\t" + sourceFilePath.FullName + "(" + lineNumber + "): error: Sharpmake.Include invalid include type used ({0})", parameters[1]);
                 }
             }
+
+            includeFilename = Environment.ExpandEnvironmentVariables(includeFilename);
+
             string includeAbsolutePath = Path.IsPathRooted(includeFilename) ? includeFilename : null;
 
             if (Util.IsPathWithWildcards(includeFilename))

--- a/Sharpmake/Builder.cs
+++ b/Sharpmake/Builder.cs
@@ -380,7 +380,8 @@ namespace Sharpmake
         private readonly Lazy<Assembly> _sharpmakeAssembly = new Lazy<Assembly>(() => Assembly.GetAssembly(typeof(Builder)));
         private readonly Lazy<Assembly> _sharpmakeGeneratorAssembly = new Lazy<Assembly>(() =>
         {
-            DirectoryInfo entryDirectoryInfo = new DirectoryInfo(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location));
+            var baseAssembly = Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly();
+            DirectoryInfo entryDirectoryInfo = new DirectoryInfo(Path.GetDirectoryName(baseAssembly.Location));
             string generatorsAssembly = entryDirectoryInfo.FullName + Path.DirectorySeparatorChar + "Sharpmake.Generators.dll";
             return Assembly.LoadFrom(generatorsAssembly);
         });

--- a/Sharpmake/Options.CSharp.cs
+++ b/Sharpmake/Options.CSharp.cs
@@ -371,6 +371,7 @@ namespace Sharpmake
                 CSharp6,
                 CSharp7,
                 CSharp7_1,
+                CSharp7_2
             }
 
             // Disable warning MSB3270 when disabled

--- a/Sharpmake/Project.Configuration.cs
+++ b/Sharpmake/Project.Configuration.cs
@@ -2524,6 +2524,7 @@ namespace Sharpmake
             public Strings ReferencesByName = new Strings();
             public Strings ReferencesByNameExternal = new Strings();
             public Strings ReferencesByPath = new Strings();
+            public Strings ReferencesByPathEmbedInterop = new Strings();
             public string ConditionalReferencesByPathCondition = string.Empty;
             public Strings ConditionalReferencesByPath = new Strings();
             public Strings ForceUsingFiles = new Strings();


### PR DESCRIPTION

Added support for the LanguageVersion CSharp7_2
Added ReferencesByPathEmbedInterop as reference type
Functional tests succeeded.