### PR TITLE
Promote Custom target elements to Project level

### DIFF
--- a/Sharpmake.Generators/VisualStudio/Vcxproj.Template.cs
+++ b/Sharpmake.Generators/VisualStudio/Vcxproj.Template.cs
@@ -452,6 +452,15 @@ namespace Sharpmake.Generators.VisualStudio
 ";
                 }
             }
+
+            public static class TargetElement
+            {
+                public static string CustomTarget =
+@"  <Target Name=""[targetElement.Name]"" [targetElement.TargetParameters]>
+    [targetElement.CustomTasks]
+  </Target>
+";
+            }
         }
     }
 }

--- a/Sharpmake.Generators/VisualStudio/Vcxproj.cs
+++ b/Sharpmake.Generators/VisualStudio/Vcxproj.cs
@@ -646,6 +646,15 @@ namespace Sharpmake.Generators.VisualStudio
             }
             fileGenerator.Write(Template.Project.ProjectTargetsEnd);
 
+            foreach (var element in context.Project.CustomTargets)
+            {
+                using (fileGenerator.Declare("project", context.Project))
+                using (fileGenerator.Declare("targetElement", element))
+                {
+                    fileGenerator.Write(Template.TargetElement.CustomTarget);
+                }
+            }
+
             // in case we are using fast build we do not want to write most dependencies
             // in the vcxproj because they are handled internally in the bff.
             // Nevertheless, non-fastbuild dependencies (such as C# projects) must be written.

--- a/Sharpmake/Project.cs
+++ b/Sharpmake/Project.cs
@@ -23,6 +23,14 @@ using System.Threading;
 namespace Sharpmake
 {
     [Resolver.Resolvable]
+    public class CustomTargetElement
+    {
+        public string Name = "";
+        public string TargetParameters = "";
+        public string CustomTasks = "";
+    }
+
+    [Resolver.Resolvable]
     public partial class Project : Configurable<Project.Configuration>
     {
         private string _name = "[project.ClassName]";                                     // Project Name
@@ -229,6 +237,7 @@ namespace Sharpmake
 
         public Strings CustomPropsFiles = new Strings();  // vs2010+ .props files
         public Strings CustomTargetsFiles = new Strings();  // vs2010+ .targets files
+        public List<CustomTargetElement> CustomTargets = new List<CustomTargetElement>();
 
         public Strings LibraryPathsExcludeFromWarningRegex = new Strings();                 // Library paths where we want to ignore the path doesn't exist warning
         public Strings IncludePathsExcludeFromWarningRegex = new Strings();                 // Include paths where we want to ignore the path doesn't exist warning
@@ -2037,7 +2046,7 @@ namespace Sharpmake
 
             aspNetProject.NoneExtensions.Add(".pubxml");
 
-            aspNetProject.CustomTargets.Add(new CSharpProject.CustomTargetElement()
+            aspNetProject.CustomTargets.Add(new CustomTargetElement()
             {
                 Name = "MvcBuildViews",
                 TargetParameters = @"AfterTargets=""AfterBuild"" Condition=""'$(MvcBuildViews)' == 'true'""",
@@ -2186,7 +2195,6 @@ namespace Sharpmake
         public List<ComReference> ComReferences = new List<ComReference>();
         public List<ImportProject> PreImportProjects = new List<ImportProject>();
         public List<ImportProject> ImportProjects = new List<ImportProject>();
-        public List<CustomTargetElement> CustomTargets = new List<CustomTargetElement>();
         public List<UsingTask> UsingTasks = new List<UsingTask>();
 
         public bool? WcfAutoStart; // Wcf Auto-Start service when debugging
@@ -2205,12 +2213,9 @@ namespace Sharpmake
         public const string DefaultImportProject = @"$(MSBuildBinPath)\Microsoft.CSharp.targets";
 
         [Resolver.Resolvable]
-        public class CustomTargetElement
+        [Obsolete("Use Sharpmake.CustomTargetElement instead.")]
+        public class CustomTargetElement : Sharpmake.CustomTargetElement
         {
-            public string Name;
-            public string TargetParameters;
-            public string CustomTasks;
-
             public CustomTargetElement()
             { }
 


### PR DESCRIPTION
Promote Custom target elements to Project level so it can also be used in vcxproj. This was mainly needed to be able to suppress auto generation of AssemblyAttributes.cpp in clr projects:

[More info](https://stackoverflow.com/questions/3104356/in-visual-studio-2010-why-is-the-netframework-version-v4-0-assemblyattributes-c)