### PR TITLE
Add an AutoDependenciesOrder option

### DIFF
--- a/Sharpmake/Project.Configuration.cs
+++ b/Sharpmake/Project.Configuration.cs
@@ -1106,7 +1106,7 @@ namespace Sharpmake
             {
                 if (_linkState != LinkState.Linking)
                     throw new Error($"Cannot add built target lib '{libraryFile}' outside of the link process of the Project.Configuration");
-                DependenciesBuiltTargetsLibraryFiles.Add(libraryFile, orderNumber);
+                DependenciesBuiltTargetsLibraryFiles.Add(libraryFile, orderNumber, OrderableStrings.OrderResolve.Greater);
             }
 
             public OrderableStrings DependenciesForceUsingFiles = new OrderableStrings();
@@ -2608,15 +2608,17 @@ namespace Sharpmake
 
             internal class DependencyNode
             {
-                internal DependencyNode(Configuration inConfiguration, DependencySetting inDependencySetting)
+                internal DependencyNode(Configuration inConfiguration, DependencySetting inDependencySetting, int autoDependenciesOrder = 0)
                 {
                     _configuration = inConfiguration;
                     _dependencySetting = inDependencySetting;
+                    _autoDependenciesOrder = autoDependenciesOrder;
                 }
 
                 internal Configuration _configuration;
                 internal DependencySetting _dependencySetting;
                 internal Dictionary<DependencyNode, DependencyType> _childNodes = new Dictionary<DependencyNode, DependencyType>();
+                internal int _autoDependenciesOrder;
             }
 
             public class VcxprojUserFileSettings
@@ -3027,6 +3029,7 @@ namespace Sharpmake
 
                 Stack<DependencyNode> visiting = new Stack<DependencyNode>();
                 visiting.Push(rootNode);
+
                 while (visiting.Count > 0)
                 {
                     DependencyNode visitedNode = visiting.Pop();
@@ -3046,6 +3049,11 @@ namespace Sharpmake
 
                     visited.Add(visitedConfiguration, visitedNode);
 
+                    if (visitedConfiguration.Project.AutoDependenciesOrder)
+                    {
+                        visitedConfiguration.TargetFileOrderNumber = Math.Max(visitedConfiguration.TargetFileOrderNumber, visitedNode._autoDependenciesOrder);
+                    }
+
                     var unresolvedDependencies = new[] { visitedConfiguration.UnResolvedPublicDependencies, visitedConfiguration.UnResolvedPrivateDependencies };
                     foreach (Dictionary<Type, ITarget> dependencies in unresolvedDependencies)
                     {
@@ -3064,7 +3072,7 @@ namespace Sharpmake
                             if (!visitedConfiguration._dependenciesSetting.TryGetValue(pair, out dependencySetting))
                                 dependencySetting = DependencySetting.Default;
 
-                            DependencyNode childNode = new DependencyNode(dependencyConf, dependencySetting);
+                            DependencyNode childNode = new DependencyNode(dependencyConf, dependencySetting, visitedNode._autoDependenciesOrder + 1);
                             System.Diagnostics.Debug.Assert(!visitedNode._childNodes.ContainsKey(childNode));
                             visitedNode._childNodes.Add(childNode, dependencyType);
 

--- a/Sharpmake/Project.cs
+++ b/Sharpmake/Project.cs
@@ -258,6 +258,13 @@ namespace Sharpmake
             set { SetProperty(ref _dependenciesOrder, value); }
         }
 
+        private bool _autoDependenciesOrder = false;
+        public bool AutoDependenciesOrder
+        {
+            get { return _autoDependenciesOrder; }
+            set { SetProperty(ref _autoDependenciesOrder, value); }
+        }
+
         // For projects that output both dll and lib depending on the configuration (often the case in TG projects)
         // Setting this to true will force dependencies regardless of different output types.
         public bool AllowInconsistentDependencies = false;

--- a/Sharpmake/Strings.cs
+++ b/Sharpmake/Strings.cs
@@ -253,7 +253,14 @@ namespace Sharpmake
                 _list.Add(new StringEntry(item));
         }
 
-        public void Add(string item, int orderNumber)
+        public enum OrderResolve
+        {
+            None,
+            Less,
+            Greater
+        }
+
+        public void Add(string item, int orderNumber, OrderResolve resolveMethod = OrderResolve.None)
         {
             if (_hashSet.Add(item))
                 _list.Add(new StringEntry(item, orderNumber));
@@ -268,9 +275,22 @@ namespace Sharpmake
                             _list[i] = new StringEntry(item, orderNumber);
                         else if (_list[i].OrderNumber != orderNumber)
                         {
-                            throw new Error(
-                                "Cannot specify 2 different non-zero order number for \"" +
-                                item + "\": " + _list[i].OrderNumber + " and " + orderNumber);
+                            if (resolveMethod == OrderResolve.Less)
+                            {
+                                if (orderNumber < _list[i].OrderNumber)
+                                    _list[i] = new StringEntry(item, orderNumber);
+                            }
+                            else if (resolveMethod == OrderResolve.Greater)
+                            {
+                                if (orderNumber > _list[i].OrderNumber)
+                                    _list[i] = new StringEntry(item, orderNumber);
+                            }
+                            else
+                            {
+                                throw new Error(
+                                    "Cannot specify 2 different non-zero order number for \"" +
+                                    item + "\": " + _list[i].OrderNumber + " and " + orderNumber);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Add an AutoDependenciesOrder option to projects that will allow them to opt into ordering their ouputs in dependency order.
This is useful on linux platforms where link order matters more.