### PR TITLE
Add support for Rust projects

### DIFF
--- a/samples/RustHelloWorld/RustHelloWorld.sharpmake.cs
+++ b/samples/RustHelloWorld/RustHelloWorld.sharpmake.cs
@@ -1,0 +1,99 @@
+﻿// Copyright (c) 2017 Ubisoft Entertainment
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Sharpmake;
+using System;
+
+namespace RustHelloWorld
+{
+    [Sharpmake.Generate]
+    public class Cpp : Project
+    {
+        public Cpp()
+        {
+            AddTargets(new Target(
+                Platform.win64,
+                DevEnv.vs2017,
+                Optimization.Debug | Optimization.Release
+            ));
+
+            RootPath = @"[project.SharpmakeCsPath]\projects\[project.Name]";
+
+            // This Path will be used to get all SourceFiles in this Folder and all subFolders
+            SourceRootPath = @"[project.SharpmakeCsPath]\codebase\[project.Name]";
+        }
+
+        [Configure()]
+        public void ConfigureAll(Configuration conf, Target target)
+        {
+            conf.ProjectFileName = "[project.Name]_[target.DevEnv]_[target.Platform]";
+            conf.ProjectPath = @"[project.SharpmakeCsPath]\projects";
+
+            conf.AddPrivateDependency<HelloWorld>(target);
+        }
+    }
+
+    [Sharpmake.Generate]
+    public class HelloWorld : RustProject
+    {
+        public HelloWorld()
+            : base(typeof(Target))
+        {
+            AddTargets(new Target(
+                Platform.win64,
+                DevEnv.vs2017,
+                Optimization.Debug | Optimization.Release
+            ));
+            
+            SourceRootPath = @"[project.SharpmakeCsPath]\codebase\[project.Name]";
+        }
+
+        [Sharpmake.Configure()]
+        public void ConfigureAll(Configuration conf, Target target)
+        {
+            ConfigureRustBuildStep(conf, target.Platform);
+
+            conf.ProjectPath = @"[project.SharpmakeCsPath]\projects";
+        }
+    }
+
+    [Sharpmake.Generate]
+    public class HelloWorldSolution : Solution
+    {
+        public HelloWorldSolution()
+        {
+            Name = "HelloWorld";
+
+            AddTargets(new Target(
+                    Platform.win64,
+                    DevEnv.vs2017,
+                    Optimization.Debug // | Optimization.Release
+            ));
+        }
+
+        [Configure()]
+        public void ConfigureAll(Configuration conf, Target target)
+        {
+            conf.SolutionFileName = "[solution.Name]_[target.DevEnv]_[target.Platform]";
+            conf.SolutionPath = @"[solution.SharpmakeCsPath]\projects";
+            conf.AddProject<Cpp>(target);
+        }
+
+        [Sharpmake.Main]
+        public static void SharpmakeMain(Sharpmake.Arguments arguments)
+        {
+            arguments.Generate<HelloWorldSolution>();
+        }
+    }
+}

--- a/samples/RustHelloWorld/codebase/Cpp/main.cpp
+++ b/samples/RustHelloWorld/codebase/Cpp/main.cpp
@@ -1,0 +1,6 @@
+#include "HelloWorld.h"
+
+int main (int, char *[])
+{
+	hello_world();
+}

--- a/samples/RustHelloWorld/codebase/helloworld/.gitignore
+++ b/samples/RustHelloWorld/codebase/helloworld/.gitignore
@@ -1,0 +1,3 @@
+target/
+ffi/
+Cargo.lock

--- a/samples/RustHelloWorld/codebase/helloworld/Cargo.toml
+++ b/samples/RustHelloWorld/codebase/helloworld/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "helloworld"
+version = "0.1.0"
+authors = ["Ubisoft"]
+edition = "2018"
+
+[lib]
+crate_type = ["staticlib"]
+
+[dependencies]

--- a/samples/RustHelloWorld/codebase/helloworld/src/lib.rs
+++ b/samples/RustHelloWorld/codebase/helloworld/src/lib.rs
@@ -1,0 +1,4 @@
+#[no_mangle]
+pub extern "C" fn hello_world() {
+    println!("Hello World");
+}

--- a/samples/Sharpmake.Samples.sharpmake.cs
+++ b/samples/Sharpmake.Samples.sharpmake.cs
@@ -195,6 +195,15 @@ namespace SharpmakeGen.Samples
     }
 
     [Generate]
+    public class RustHelloWorldProject : SampleProject
+    {
+        public RustHelloWorldProject()
+        {
+            Name = "RustHelloWorld";
+        }
+    }
+
+    [Generate]
     public class SimpleExeLibDependencyProject : SampleProject
     {
         public SimpleExeLibDependencyProject()


### PR DESCRIPTION
This is an initial pass on adding support for Rust projects to Sharpmake. Rust works slightly different compared to C# or C++ because it includes a build system called [`Cargo`](https://doc.rust-lang.org/cargo/reference/manifest.html) that specifies all dependencies, linking options, debug options, etc.

Notes:
- As I don't have a macOS system, I've only tested it on Windows so far.
- The generated `RustHelloWorld` solution always complains about an invalid Windows SDK version:
    ```bash
    2>C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\Common7\IDE\VC\VCTargets\Microsoft.Cpp.WindowsSDK.targets(46,5): error MSB8036: The Windows SDK version 10.0.10586.0 was not found. Install the required version of Windows SDK or change the SDK version in the project property pages or by right-clicking the solution and selecting "Retarget solution".
    ```
    Do you have any recommendation on how to prevent that?

I'd love for you to give me feedback on what I can improve about my implementation.

