### PR TITLE
Added Clang support for VS2019.

### DIFF
--- a/Sharpmake.Generators/VisualStudio/ProjectOptionsGenerator.cs
+++ b/Sharpmake.Generators/VisualStudio/ProjectOptionsGenerator.cs
@@ -1111,7 +1111,8 @@ namespace Sharpmake.Generators.VisualStudio
                 Options.Option(Options.Vc.General.PlatformToolset.v142, () => { context.Options["PlatformToolset"] = "v142"; }),
                 Options.Option(Options.Vc.General.PlatformToolset.LLVM_vs2012, () => { context.Options["PlatformToolset"] = "LLVM-vs2012"; context.Options["TrackFileAccess"] = "false"; }),
                 Options.Option(Options.Vc.General.PlatformToolset.LLVM_vs2014, () => { context.Options["PlatformToolset"] = "LLVM-vs2014"; }),
-                Options.Option(Options.Vc.General.PlatformToolset.LLVM, () => { context.Options["PlatformToolset"] = "llvm"; })
+                Options.Option(Options.Vc.General.PlatformToolset.LLVM_vs2017, () => { context.Options["PlatformToolset"] = "llvm"; }),
+                Options.Option(Options.Vc.General.PlatformToolset.LLVM, () => { context.Options["PlatformToolset"] = "ClangCL"; })
             );
             optionsContext.PlatformVcxproj.SetupPlatformToolsetOptions(context);
         }

--- a/Sharpmake/Options.Vc.cs
+++ b/Sharpmake/Options.Vc.cs
@@ -50,7 +50,9 @@ namespace Sharpmake
                     [DevEnvVersion(minimum = DevEnv.vs2015)]
                     LLVM_vs2014, // LLVM from Visual Studio 2015
                     [DevEnvVersion(minimum = DevEnv.vs2017)]
-                    LLVM, // LLVM from Visual Studio 2017
+                    LLVM_vs2017, // LLVM from Visual Studio 2017
+                    [DevEnvVersion(minimum = DevEnv.vs2019)]
+                    LLVM, // LLVM from Visual Studio 2019
                 }
 
                 public enum WindowsTargetPlatformVersion

--- a/Sharpmake/Util.cs
+++ b/Sharpmake/Util.cs
@@ -1775,7 +1775,7 @@ namespace Sharpmake
                 Environment.Is64BitProcess ? @"\Wow6432Node" : string.Empty
             );
 
-            return GetRegistryLocalMachineSubKeyValue(registryKeyString, null, @"C:\Program Files\LLVM"); // null to get default
+            return GetRegistryLocalMachineSubKeyValue(registryKeyString, null, @"$(LLVMInstallDir)"); // null to get default
         }
 
         public static string GetClangVersionFromLLVMInstallDir(string llvmInstallDir)


### PR DESCRIPTION
Visual Studio 2019 has native support of llvm toolchain, making sure sharpmake works with it.