### PR TITLE
[Cleanup] Remove unused StaticOutputLibraryFileExtension

### DIFF
--- a/Sharpmake.Generators/VisualStudio/IPlatformVcxproj.cs
+++ b/Sharpmake.Generators/VisualStudio/IPlatformVcxproj.cs
@@ -36,7 +36,6 @@ namespace Sharpmake.Generators.VisualStudio
         string SharedLibraryFileExtension { get; }
         string ProgramDatabaseFileExtension { get; }
         string StaticLibraryFileExtension { get; }
-        string StaticOutputLibraryFileExtension { get; }
         bool ExcludesPrecompiledHeadersFromBuild { get; }
         bool HasUserAccountControlSupport { get; }
         bool HasEditAndContinueDebuggingSupport { get; }

--- a/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Apple/BaseApplePlatform.cs
+++ b/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Apple/BaseApplePlatform.cs
@@ -332,7 +332,6 @@ namespace Sharpmake
         public string SharedLibraryFileExtension => "dylib";
         public string ProgramDatabaseFileExtension => string.Empty;
         public string StaticLibraryFileExtension => "a";
-        public string StaticOutputLibraryFileExtension => StaticLibraryFileExtension;
         public bool ExcludesPrecompiledHeadersFromBuild => false;
         public bool HasUserAccountControlSupport => false;
         public bool HasEditAndContinueDebuggingSupport => false;

--- a/Sharpmake.Platforms/Sharpmake.CommonPlatforms/BasePlatform.cs
+++ b/Sharpmake.Platforms/Sharpmake.CommonPlatforms/BasePlatform.cs
@@ -146,7 +146,6 @@ namespace Sharpmake
         public abstract string SharedLibraryFileExtension { get; }
         public abstract string ProgramDatabaseFileExtension { get; }
         public virtual string StaticLibraryFileExtension => "lib";
-        public virtual string StaticOutputLibraryFileExtension => StaticLibraryFileExtension;
         public virtual bool ExcludesPrecompiledHeadersFromBuild => false;
         public virtual bool HasUserAccountControlSupport => false;
         public virtual bool HasEditAndContinueDebuggingSupport => false;

--- a/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Linux/LinuxPlatform.cs
+++ b/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Linux/LinuxPlatform.cs
@@ -86,7 +86,6 @@ namespace Sharpmake
             public override string ProgramDatabaseFileExtension => string.Empty;
             public override string StaticLibraryFileExtension => "a";
             public override string SharedLibraryFileExtension => "so";
-            public override string StaticOutputLibraryFileExtension => string.Empty;
             public override string ExecutableFileExtension => string.Empty;
 
             // Ideally the object files should be suffixed .o when compiling with FastBuild, using the CompilerOutputExtension property in ObjectLists

--- a/Sharpmake.Platforms/Sharpmake.NvShield/NvShieldPlatform.cs
+++ b/Sharpmake.Platforms/Sharpmake.NvShield/NvShieldPlatform.cs
@@ -69,7 +69,6 @@ namespace Sharpmake
             public override string SharedLibraryFileExtension => "so";
             public override string ProgramDatabaseFileExtension => "so";
             public override string StaticLibraryFileExtension => string.Empty;
-            public override string StaticOutputLibraryFileExtension => string.Empty;
 
             public override string GetOutputFileNamePrefix(IGenerationContext context, Project.Configuration.OutputType outputType)
             {


### PR DESCRIPTION
This field isn't used anywhere, so just a simple code cleanup.