### PR TITLE
Android fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 !Sharpmake.Platforms/Sharpmake.CommonPlatforms/Sharpmake.CommonPlatforms.csproj
 
 # Samples and FunctionalTests generated projects
+samples/*/package/*.androidproj
+samples/*/package/temp*
 samples/*/projects/*
 samples/HelloXCode/codebase/temp*
 Sharpmake.FunctionalTests/*/projects/*

--- a/Sharpmake.Generators/FastBuild/Bff.cs
+++ b/Sharpmake.Generators/FastBuild/Bff.cs
@@ -1628,7 +1628,7 @@ namespace Sharpmake.Generators.FastBuild
                     // here we could also verify that the path is rooted
                     if (extension != platformVcxproj.StaticLibraryFileExtension && extension != platformVcxproj.SharedLibraryFileExtension)
                     {
-                        libraryFile = libPrefix + libraryFile;
+                        libraryFile = Util.PathAddPrefixToFileName(libPrefix, libraryFile);
                         if (!string.IsNullOrEmpty(platformVcxproj.StaticLibraryFileExtension))
                             libraryFile += "." + platformVcxproj.StaticLibraryFileExtension;
                     }

--- a/Sharpmake.Generators/VisualStudio/Androidproj.Template.cs
+++ b/Sharpmake.Generators/VisualStudio/Androidproj.Template.cs
@@ -138,8 +138,12 @@ namespace Sharpmake.Generators.VisualStudio
 @"    <ClInclude Include=""[file.FileNameProjectRelative]"" />
 ";
 
-                public static string ContentSimple =
-@"    <Content Include=""[file.FileNameSourceRelative]"" />
+                public const string ProjectFilesJavaSource =
+@"    <JavaCompile Include=""[file.FileNameProjectRelative]"" />
+";
+
+                public const string ProjectFilesContent =
+@"    <Content Include=""[file.FileNameProjectRelative]"" />
 ";
             }
         }

--- a/Sharpmake.Generators/VisualStudio/Androidproj.cs
+++ b/Sharpmake.Generators/VisualStudio/Androidproj.cs
@@ -258,7 +258,7 @@ namespace Sharpmake.Generators.VisualStudio
             // Add source files
             var allFiles = new List<Vcxproj.ProjectFile>();
             var includeFiles = new List<Vcxproj.ProjectFile>();
-            var sourceFiles = new List<Vcxproj.ProjectFile>();
+            var javaSourceFiles = new List<Vcxproj.ProjectFile>();
             var contentFiles = new List<Vcxproj.ProjectFile>();
 
             foreach (string file in projectFiles)
@@ -285,9 +285,9 @@ namespace Sharpmake.Generators.VisualStudio
                     files.Add(projectFile);
                 }
                 else if (context.Project.SourceFilesCompileExtensions.Contains(projectFile.FileExtension) ||
-                         (String.Compare(projectFile.FileExtension, ".rc", StringComparison.OrdinalIgnoreCase) == 0))
+                         (String.Compare(projectFile.FileExtension, ".java", StringComparison.OrdinalIgnoreCase) == 0))
                 {
-                    sourceFiles.Add(projectFile);
+                    javaSourceFiles.Add(projectFile);
                 }
                 else if (String.Compare(projectFile.FileExtension, ".h", StringComparison.OrdinalIgnoreCase) == 0)
                 {
@@ -308,12 +308,21 @@ namespace Sharpmake.Generators.VisualStudio
             }
             fileGenerator.Write(Template.Project.ProjectFilesEnd);
 
+            // Write java files
+            fileGenerator.Write(Template.Project.ProjectFilesBegin);
+            foreach (var file in javaSourceFiles)
+            {
+                using (fileGenerator.Declare("file", file))
+                    fileGenerator.Write(Template.Project.ProjectFilesJavaSource);
+            }
+            fileGenerator.Write(Template.Project.ProjectFilesEnd);
+
             // Write content files
             fileGenerator.Write(Template.Project.ProjectFilesBegin);
             foreach (var file in contentFiles)
             {
                 using (fileGenerator.Declare("file", file))
-                    fileGenerator.Write(Template.Project.ContentSimple);
+                    fileGenerator.Write(Template.Project.ProjectFilesContent);
             }
             fileGenerator.Write(Template.Project.ProjectFilesEnd);
 

--- a/Sharpmake.Generators/VisualStudio/Vcxproj.cs
+++ b/Sharpmake.Generators/VisualStudio/Vcxproj.cs
@@ -813,7 +813,7 @@ namespace Sharpmake.Generators.VisualStudio
 
                 if (extension != platformVcxproj.StaticLibraryFileExtension && extension != platformVcxproj.SharedLibraryFileExtension)
                 {
-                    decoratedName = libPrefix + libraryFile;
+                    decoratedName = Util.PathAddPrefixToFileName(libPrefix, libraryFile);
                     if (!string.IsNullOrEmpty(platformVcxproj.StaticLibraryFileExtension))
                         decoratedName += "." + platformVcxproj.StaticLibraryFileExtension;
                 }

--- a/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Android/AndroidPlatform.cs
+++ b/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Android/AndroidPlatform.cs
@@ -65,8 +65,20 @@ namespace Sharpmake
             #region Project.Configuration.IConfigurationTasks implementation
             public void SetupDynamicLibraryPaths(Project.Configuration configuration, DependencySetting dependencySetting, Project.Configuration dependency)
             {
-                // Not tested. We may need to root the path like we do in SetupStaticLibraryPaths.
-                DefaultPlatform.SetupLibraryPaths(configuration, dependencySetting, dependency);
+                if (!dependency.Project.GetType().IsDefined(typeof(Export), false))
+                {
+                    if (dependencySetting.HasFlag(DependencySetting.LibraryPaths))
+                        configuration.AddDependencyBuiltTargetLibraryPath(dependency.TargetLibraryPath, dependency.TargetLibraryPathOrderNumber);
+                }
+                else
+                {
+                    if (dependencySetting.HasFlag(DependencySetting.LibraryPaths))
+                        configuration.DependenciesOtherLibraryPaths.Add(dependency.TargetLibraryPath, dependency.TargetLibraryPathOrderNumber);
+                }
+
+                // Reference library using -l<name>, build system knows to look for lib<name>.so
+                if (dependencySetting.HasFlag(DependencySetting.LibraryFiles))
+                    configuration.AdditionalLinkerOptions.Add("-l" + dependency.TargetFileName);
             }
 
             public void SetupStaticLibraryPaths(Project.Configuration configuration, DependencySetting dependencySetting, Project.Configuration dependency)

--- a/Sharpmake/Project.cs
+++ b/Sharpmake/Project.cs
@@ -2637,6 +2637,7 @@ namespace Sharpmake
 
         public AndroidPackageProject(Type targetType) : base(targetType)
         {
+            SourceFilesExtensions = new Strings(".java", ".xml");
         }
     }
 }

--- a/Sharpmake/Util.cs
+++ b/Sharpmake/Util.cs
@@ -183,6 +183,14 @@ namespace Sharpmake
             pathName = pathName.TrimEnd(Path.DirectorySeparatorChar);
         }
 
+        public static string PathAddPrefixToFileName(string fileFullPath, string prefix)
+        {
+            string fileName;
+            string pathName;
+            PathSplitFileNameFromPath(fileFullPath, out fileName, out pathName);
+            return Path.Combine(pathName, prefix + fileFullPath);
+        }
+
         public static string RegexPathCombine(params string[] parts)
         {
             StringBuilder stringBuilder = new StringBuilder();

--- a/UpdateSamplesOutput.bat
+++ b/UpdateSamplesOutput.bat
@@ -19,6 +19,8 @@ call :UpdateRef samples CSharpHelloWorld            HelloWorld.sharpmake.cs     
 if not "%ERRORLEVEL_BACKUP%" == "0" goto error
 call :UpdateRef samples HelloWorld                  HelloWorld.sharpmake.cs                    reference         HelloWorld
 if not "%ERRORLEVEL_BACKUP%" == "0" goto error
+call :UpdateRef samples HelloAndroid                HelloAndroid.sharpmake.cs                  reference         HelloAndroid
+if not "%ERRORLEVEL_BACKUP%" == "0" goto error
 call :UpdateRef samples CSharpVsix                  CSharpVsix.sharpmake.cs                    reference         CSharpVsix
 if not "%ERRORLEVEL_BACKUP%" == "0" goto error
 call :UpdateRef samples CSharpWCF                   CSharpWCF.sharpmake.cs                     reference         CSharpWCF\codebase

--- a/samples/HelloAndroid/HelloAndroid.Projects.sharpmake.cs
+++ b/samples/HelloAndroid/HelloAndroid.Projects.sharpmake.cs
@@ -1,0 +1,64 @@
+﻿using Sharpmake;
+
+namespace HelloAndroid
+{
+    [Generate]
+    public class HelloAndroidProject : Project
+    {
+        public HelloAndroidProject()
+            : base(typeof(AndroidTarget))
+        {
+            RootPath = @"[project.SharpmakeCsPath]\codebase";
+            SourceRootPath = @"[project.RootPath]";
+            AddTargets(AndroidTarget.GetDefaultTargets());
+        }
+
+        [Configure()]
+        public virtual void ConfigureAll(Configuration conf, Target target)
+        {
+            conf.ProjectPath = @"[project.SharpmakeCsPath]\projects\";
+            conf.ProjectFileName = @"[project.Name].[target.DevEnv]";
+            conf.IntermediatePath = @"[conf.ProjectPath]\temp\[target.DevEnv]\[target.Platform]\[target]";
+
+
+            // Natice Android projects are compiled as dlls, not exes
+            conf.Output = Configuration.OutputType.Dll;
+
+            // Required options
+            conf.Options.Add(Options.Android.General.ThumbMode.Disabled);
+            conf.Options.Add(Options.Android.General.UseOfStl.GnuStl_Static);
+            conf.Options.Add(Options.Android.General.AndroidAPILevel.Android21);
+            conf.Options.Add(Options.Android.General.WarningLevel.EnableAllWarnings);
+            conf.Options.Add(Options.Android.Compiler.CppLanguageStandard.Cpp11);
+
+            conf.AdditionalLinkerOptions.Add("-lGLESv1_CM", "-lEGL");
+        }
+    }
+
+    [Generate]
+    class HelloAndroidPackage : AndroidPackageProject
+    {
+        public HelloAndroidPackage()
+            : base(typeof(AndroidTarget))
+        {
+            RootPath = @"[project.SharpmakeCsPath]\package";
+            SourceRootPath = @"[project.RootPath]";
+            AddTargets(AndroidTarget.GetDefaultTargets());
+            AppLibType = typeof(HelloAndroidProject);
+        }
+
+        [Configure()]
+        public virtual void ConfigureAll(Configuration conf, Target target)
+        {
+            conf.Options.Add(Options.Android.General.AndroidAPILevel.Android21);
+
+            // AndroidPackage projects MUST be in the same directory as their content
+            conf.ProjectPath = @"[project.RootPath]";
+            conf.ProjectFileName = @"[project.Name].[target.DevEnv]";
+            conf.IntermediatePath = @"[conf.ProjectPath]\temp\[target.DevEnv]\[target.Platform]\[target]";
+            conf.DeployProject = true;
+
+            conf.AddPrivateDependency<HelloAndroidProject>(target);
+        }
+    }
+}

--- a/samples/HelloAndroid/HelloAndroid.Solution.sharpmake.cs
+++ b/samples/HelloAndroid/HelloAndroid.Solution.sharpmake.cs
@@ -1,0 +1,25 @@
+﻿using Sharpmake;
+
+namespace HelloAndroid
+{
+    [Sharpmake.Generate]
+    public class HelloAndroidSolution : Solution
+    {
+        public HelloAndroidSolution()
+            : base(typeof(AndroidTarget))
+        {
+            Name = "HelloAndroid";
+            AddTargets(AndroidTarget.GetDefaultTargets());
+        }
+
+        [Configure()]
+        public void ConfigureAll(Configuration conf, Target target)
+        {
+            conf.SolutionFileName = "[solution.Name].[target.DevEnv]";
+
+            conf.SolutionPath = @"[solution.SharpmakeCsPath]\projects\";
+
+            conf.AddProject<HelloAndroidPackage>(target);
+        }
+    }
+}

--- a/samples/HelloAndroid/HelloAndroid.Target.sharpmake.cs
+++ b/samples/HelloAndroid/HelloAndroid.Target.sharpmake.cs
@@ -1,0 +1,34 @@
+﻿using Sharpmake;
+
+namespace HelloAndroid
+{
+    public class AndroidTarget : Target
+    {
+        public Android.AndroidBuildTargets AndroidBuildTargets;
+
+        public AndroidTarget() { }
+
+        public AndroidTarget(
+            Platform platform,
+            DevEnv devEnv,
+            Optimization optimization,
+            Android.AndroidBuildTargets androidBuildTargets
+        ) : base(platform, devEnv, optimization)
+        {
+            AndroidBuildTargets = androidBuildTargets;
+        }
+
+        public static Target[] GetDefaultTargets()
+        {
+            return new[]
+            {
+                new AndroidTarget(
+                    Platform.android,
+                    DevEnv.vs2017,
+                    Optimization.Debug | Optimization.Release,
+                    Android.AndroidBuildTargets.arm64_v8a | Android.AndroidBuildTargets.armeabi_v7a | Android.AndroidBuildTargets.x86 | Android.AndroidBuildTargets.x86_64),
+            };
+        }
+    }
+}
+

--- a/samples/HelloAndroid/HelloAndroid.sharpmake.cs
+++ b/samples/HelloAndroid/HelloAndroid.sharpmake.cs
@@ -1,0 +1,20 @@
+﻿using Sharpmake;
+
+[module: Sharpmake.Include("HelloAndroid.Projects.sharpmake.cs")]
+[module: Sharpmake.Include("HelloAndroid.Solution.sharpmake.cs")]
+[module: Sharpmake.Include("HelloAndroid.Target.sharpmake.cs")]
+
+[module: Sharpmake.DebugProjectName("Sharpmake.HelloAndroid")]
+
+namespace HelloAndroid
+{
+    public static class StartupClass
+    {
+        [Sharpmake.Main]
+        public static void SharpmakeMain(Sharpmake.Arguments arguments)
+        {
+            arguments.Generate<HelloAndroidSolution>();
+        }
+    }
+}
+

--- a/samples/HelloAndroid/codebase/Cube.cpp
+++ b/samples/HelloAndroid/codebase/Cube.cpp
@@ -1,0 +1,85 @@
+#include "Cube.h"
+
+float _rotation;
+
+static GLint vertices[][3] =
+{
+    { -0x10000, -0x10000, -0x10000 },
+    { 0x10000, -0x10000, -0x10000 },
+    { 0x10000,  0x10000, -0x10000 },
+    { -0x10000,  0x10000, -0x10000 },
+    { -0x10000, -0x10000,  0x10000 },
+    { 0x10000, -0x10000,  0x10000 },
+    { 0x10000,  0x10000,  0x10000 },
+    { -0x10000,  0x10000,  0x10000 }
+};
+
+static GLint colors[][4] =
+{
+    { 0x00000, 0x00000, 0x00000, 0x10000 },
+    { 0x10000, 0x00000, 0x00000, 0x10000 },
+    { 0x10000, 0x10000, 0x00000, 0x10000 },
+    { 0x00000, 0x10000, 0x00000, 0x10000 },
+    { 0x00000, 0x00000, 0x10000, 0x10000 },
+    { 0x10000, 0x00000, 0x10000, 0x10000 },
+    { 0x10000, 0x10000, 0x10000, 0x10000 },
+    { 0x00000, 0x10000, 0x10000, 0x10000 }
+};
+
+GLubyte indices[] =
+{
+    0, 4, 5,    0, 5, 1,
+    1, 5, 6,    1, 6, 2,
+    2, 6, 7,    2, 7, 3,
+    3, 7, 4,    3, 4, 0,
+    4, 7, 6,    4, 6, 5,
+    3, 0, 1,    3, 1, 2
+};
+
+void Cube_setupGL(double width, double height)
+{
+    // Initialize GL state.
+    glDisable(GL_DITHER);
+    glHint(GL_PERSPECTIVE_CORRECTION_HINT, GL_FASTEST);
+    glClearColor(1.0f, 0.41f, 0.71f, 1.0f);
+    glEnable(GL_CULL_FACE);
+    glShadeModel(GL_SMOOTH);
+    glEnable(GL_DEPTH_TEST);
+
+    glViewport(0, 0, width, height);
+    GLfloat ratio = (GLfloat)width / height;
+    glMatrixMode(GL_PROJECTION);
+    glLoadIdentity();
+    glFrustumf(-ratio, ratio, -1, 1, 1, 10);
+}
+
+void Cube_tearDownGL()
+{
+}
+
+void Cube_update()
+{
+    _rotation += 1.f;
+
+}
+void Cube_prepare()
+{
+     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+}
+
+void Cube_draw()
+{
+    glMatrixMode(GL_MODELVIEW);
+    glLoadIdentity();
+    glTranslatef(0, 0, -3.0f);
+    glRotatef(_rotation * 0.25f, 1, 0, 0);  // X
+    glRotatef(_rotation, 0, 1, 0);          // Y
+
+    glEnableClientState(GL_VERTEX_ARRAY);
+    glEnableClientState(GL_COLOR_ARRAY);
+
+    glFrontFace(GL_CW);
+    glVertexPointer(3, GL_FIXED, 0, vertices);
+    glColorPointer(4, GL_FIXED, 0, colors);
+    glDrawElements(GL_TRIANGLES, 36, GL_UNSIGNED_BYTE, indices);
+}

--- a/samples/HelloAndroid/codebase/Cube.h
+++ b/samples/HelloAndroid/codebase/Cube.h
@@ -1,0 +1,17 @@
+#ifndef __HelloCubeNative__main__
+#define __HelloCubeNative__main__
+
+#include <stdio.h>
+#ifdef __ANDROID__
+#include <GLES/gl.h>
+#elif __APPLE__
+#include <OpenGLES/ES1/gl.h>
+#endif
+
+void Cube_setupGL(double width, double height);
+void Cube_tearDownGL();
+void Cube_update();
+void Cube_prepare();
+void Cube_draw();
+
+#endif /* defined(__HelloCubeNative__main__) */

--- a/samples/HelloAndroid/codebase/android_native_app_glue.c
+++ b/samples/HelloAndroid/codebase/android_native_app_glue.c
@@ -1,0 +1,428 @@
+/*
+ * Copyright (C) 2010 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "pch.h"
+
+#define LOGI(...) ((void)__android_log_print(ANDROID_LOG_INFO, "threaded_app", __VA_ARGS__))
+#define LOGE(...) ((void)__android_log_print(ANDROID_LOG_ERROR, "threaded_app", __VA_ARGS__))
+
+/* For debug builds, always enable the debug traces in this library */
+#ifndef NDEBUG
+#  define LOGV(...)  ((void)__android_log_print(ANDROID_LOG_VERBOSE, "threaded_app", __VA_ARGS__))
+#else
+#  define LOGV(...)  ((void)0)
+#endif
+
+static void free_saved_state(struct android_app* android_app) {
+    pthread_mutex_lock(&android_app->mutex);
+    if (android_app->savedState != NULL) {
+        free(android_app->savedState);
+        android_app->savedState = NULL;
+        android_app->savedStateSize = 0;
+    }
+    pthread_mutex_unlock(&android_app->mutex);
+}
+
+int8_t android_app_read_cmd(struct android_app* android_app) {
+    int8_t cmd;
+    if (read(android_app->msgread, &cmd, sizeof(cmd)) == sizeof(cmd)) {
+        switch (cmd) {
+            case APP_CMD_SAVE_STATE:
+                free_saved_state(android_app);
+                break;
+        }
+        return cmd;
+    } else {
+        LOGE("No data on command pipe!");
+    }
+    return -1;
+}
+
+static void print_cur_config(struct android_app* android_app) {
+    char lang[2], country[2];
+    AConfiguration_getLanguage(android_app->config, lang);
+    AConfiguration_getCountry(android_app->config, country);
+
+    LOGV("Config: mcc=%d mnc=%d lang=%c%c cnt=%c%c orien=%d touch=%d dens=%d "
+            "keys=%d nav=%d keysHid=%d navHid=%d sdk=%d size=%d long=%d "
+            "modetype=%d modenight=%d",
+            AConfiguration_getMcc(android_app->config),
+            AConfiguration_getMnc(android_app->config),
+            lang[0], lang[1], country[0], country[1],
+            AConfiguration_getOrientation(android_app->config),
+            AConfiguration_getTouchscreen(android_app->config),
+            AConfiguration_getDensity(android_app->config),
+            AConfiguration_getKeyboard(android_app->config),
+            AConfiguration_getNavigation(android_app->config),
+            AConfiguration_getKeysHidden(android_app->config),
+            AConfiguration_getNavHidden(android_app->config),
+            AConfiguration_getSdkVersion(android_app->config),
+            AConfiguration_getScreenSize(android_app->config),
+            AConfiguration_getScreenLong(android_app->config),
+            AConfiguration_getUiModeType(android_app->config),
+            AConfiguration_getUiModeNight(android_app->config));
+}
+
+void android_app_pre_exec_cmd(struct android_app* android_app, int8_t cmd) {
+    switch (cmd) {
+        case APP_CMD_INPUT_CHANGED:
+            LOGV("APP_CMD_INPUT_CHANGED\n");
+            pthread_mutex_lock(&android_app->mutex);
+            if (android_app->inputQueue != NULL) {
+                AInputQueue_detachLooper(android_app->inputQueue);
+            }
+            android_app->inputQueue = android_app->pendingInputQueue;
+            if (android_app->inputQueue != NULL) {
+                LOGV("Attaching input queue to looper");
+                AInputQueue_attachLooper(android_app->inputQueue,
+                        android_app->looper, LOOPER_ID_INPUT, NULL,
+                        &android_app->inputPollSource);
+            }
+            pthread_cond_broadcast(&android_app->cond);
+            pthread_mutex_unlock(&android_app->mutex);
+            break;
+
+        case APP_CMD_INIT_WINDOW:
+            LOGV("APP_CMD_INIT_WINDOW\n");
+            pthread_mutex_lock(&android_app->mutex);
+            android_app->window = android_app->pendingWindow;
+            pthread_cond_broadcast(&android_app->cond);
+            pthread_mutex_unlock(&android_app->mutex);
+            break;
+
+        case APP_CMD_TERM_WINDOW:
+            LOGV("APP_CMD_TERM_WINDOW\n");
+            pthread_cond_broadcast(&android_app->cond);
+            break;
+
+        case APP_CMD_RESUME:
+        case APP_CMD_START:
+        case APP_CMD_PAUSE:
+        case APP_CMD_STOP:
+            LOGV("activityState=%d\n", cmd);
+            pthread_mutex_lock(&android_app->mutex);
+            android_app->activityState = cmd;
+            pthread_cond_broadcast(&android_app->cond);
+            pthread_mutex_unlock(&android_app->mutex);
+            break;
+
+        case APP_CMD_CONFIG_CHANGED:
+            LOGV("APP_CMD_CONFIG_CHANGED\n");
+            AConfiguration_fromAssetManager(android_app->config,
+                    android_app->activity->assetManager);
+            print_cur_config(android_app);
+            break;
+
+        case APP_CMD_DESTROY:
+            LOGV("APP_CMD_DESTROY\n");
+            android_app->destroyRequested = 1;
+            break;
+    }
+}
+
+void android_app_post_exec_cmd(struct android_app* android_app, int8_t cmd) {
+    switch (cmd) {
+        case APP_CMD_TERM_WINDOW:
+            LOGV("APP_CMD_TERM_WINDOW\n");
+            pthread_mutex_lock(&android_app->mutex);
+            android_app->window = NULL;
+            pthread_cond_broadcast(&android_app->cond);
+            pthread_mutex_unlock(&android_app->mutex);
+            break;
+
+        case APP_CMD_SAVE_STATE:
+            LOGV("APP_CMD_SAVE_STATE\n");
+            pthread_mutex_lock(&android_app->mutex);
+            android_app->stateSaved = 1;
+            pthread_cond_broadcast(&android_app->cond);
+            pthread_mutex_unlock(&android_app->mutex);
+            break;
+
+        case APP_CMD_RESUME:
+            free_saved_state(android_app);
+            break;
+    }
+}
+
+static void android_app_destroy(struct android_app* android_app) {
+    LOGV("android_app_destroy!");
+    free_saved_state(android_app);
+    pthread_mutex_lock(&android_app->mutex);
+    if (android_app->inputQueue != NULL) {
+        AInputQueue_detachLooper(android_app->inputQueue);
+    }
+    AConfiguration_delete(android_app->config);
+    android_app->destroyed = 1;
+    pthread_cond_broadcast(&android_app->cond);
+    pthread_mutex_unlock(&android_app->mutex);
+    // Can't touch android_app object after this.
+}
+
+static void process_input(struct android_app* app, struct android_poll_source* source) {
+    AInputEvent* event = NULL;
+    while (AInputQueue_getEvent(app->inputQueue, &event) >= 0) {
+        LOGV("New input event: type=%d\n", AInputEvent_getType(event));
+        if (AInputQueue_preDispatchEvent(app->inputQueue, event)) {
+            continue;
+        }
+        int32_t handled = 0;
+        if (app->onInputEvent != NULL) handled = app->onInputEvent(app, event);
+        AInputQueue_finishEvent(app->inputQueue, event, handled);
+    }
+}
+
+static void process_cmd(struct android_app* app, struct android_poll_source* source) {
+    int8_t cmd = android_app_read_cmd(app);
+    android_app_pre_exec_cmd(app, cmd);
+    if (app->onAppCmd != NULL) app->onAppCmd(app, cmd);
+    android_app_post_exec_cmd(app, cmd);
+}
+
+static void* android_app_entry(void* param) {
+    struct android_app* android_app = (struct android_app*)param;
+
+    android_app->config = AConfiguration_new();
+    AConfiguration_fromAssetManager(android_app->config, android_app->activity->assetManager);
+
+    print_cur_config(android_app);
+
+    android_app->cmdPollSource.id = LOOPER_ID_MAIN;
+    android_app->cmdPollSource.app = android_app;
+    android_app->cmdPollSource.process = process_cmd;
+    android_app->inputPollSource.id = LOOPER_ID_INPUT;
+    android_app->inputPollSource.app = android_app;
+    android_app->inputPollSource.process = process_input;
+
+    ALooper* looper = ALooper_prepare(ALOOPER_PREPARE_ALLOW_NON_CALLBACKS);
+    ALooper_addFd(looper, android_app->msgread, LOOPER_ID_MAIN, ALOOPER_EVENT_INPUT, NULL,
+            &android_app->cmdPollSource);
+    android_app->looper = looper;
+
+    pthread_mutex_lock(&android_app->mutex);
+    android_app->running = 1;
+    pthread_cond_broadcast(&android_app->cond);
+    pthread_mutex_unlock(&android_app->mutex);
+
+    android_main(android_app);
+
+    android_app_destroy(android_app);
+    return NULL;
+}
+
+// --------------------------------------------------------------------
+// Native activity interaction (called from main thread)
+// --------------------------------------------------------------------
+
+static struct android_app* android_app_create(ANativeActivity* activity,
+        void* savedState, size_t savedStateSize) {
+    struct android_app* android_app = (struct android_app*)malloc(sizeof(struct android_app));
+    memset(android_app, 0, sizeof(struct android_app));
+    android_app->activity = activity;
+
+    pthread_mutex_init(&android_app->mutex, NULL);
+    pthread_cond_init(&android_app->cond, NULL);
+
+    if (savedState != NULL) {
+        android_app->savedState = malloc(savedStateSize);
+        android_app->savedStateSize = savedStateSize;
+        memcpy(android_app->savedState, savedState, savedStateSize);
+    }
+
+    int msgpipe[2];
+    if (pipe(msgpipe)) {
+        LOGE("could not create pipe: %s", strerror(errno));
+        return NULL;
+    }
+    android_app->msgread = msgpipe[0];
+    android_app->msgwrite = msgpipe[1];
+
+    pthread_attr_t attr;
+    pthread_attr_init(&attr);
+    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+    pthread_create(&android_app->thread, &attr, android_app_entry, android_app);
+
+    // Wait for thread to start.
+    pthread_mutex_lock(&android_app->mutex);
+    while (!android_app->running) {
+        pthread_cond_wait(&android_app->cond, &android_app->mutex);
+    }
+    pthread_mutex_unlock(&android_app->mutex);
+
+    return android_app;
+}
+
+static void android_app_write_cmd(struct android_app* android_app, int8_t cmd) {
+    if (write(android_app->msgwrite, &cmd, sizeof(cmd)) != sizeof(cmd)) {
+        LOGE("Failure writing android_app cmd: %s\n", strerror(errno));
+    }
+}
+
+static void android_app_set_input(struct android_app* android_app, AInputQueue* inputQueue) {
+    pthread_mutex_lock(&android_app->mutex);
+    android_app->pendingInputQueue = inputQueue;
+    android_app_write_cmd(android_app, APP_CMD_INPUT_CHANGED);
+    while (android_app->inputQueue != android_app->pendingInputQueue) {
+        pthread_cond_wait(&android_app->cond, &android_app->mutex);
+    }
+    pthread_mutex_unlock(&android_app->mutex);
+}
+
+static void android_app_set_window(struct android_app* android_app, ANativeWindow* window) {
+    pthread_mutex_lock(&android_app->mutex);
+    if (android_app->pendingWindow != NULL) {
+        android_app_write_cmd(android_app, APP_CMD_TERM_WINDOW);
+    }
+    android_app->pendingWindow = window;
+    if (window != NULL) {
+        android_app_write_cmd(android_app, APP_CMD_INIT_WINDOW);
+    }
+    while (android_app->window != android_app->pendingWindow) {
+        pthread_cond_wait(&android_app->cond, &android_app->mutex);
+    }
+    pthread_mutex_unlock(&android_app->mutex);
+}
+
+static void android_app_set_activity_state(struct android_app* android_app, int8_t cmd) {
+    pthread_mutex_lock(&android_app->mutex);
+    android_app_write_cmd(android_app, cmd);
+    while (android_app->activityState != cmd) {
+        pthread_cond_wait(&android_app->cond, &android_app->mutex);
+    }
+    pthread_mutex_unlock(&android_app->mutex);
+}
+
+static void android_app_free(struct android_app* android_app) {
+    pthread_mutex_lock(&android_app->mutex);
+    android_app_write_cmd(android_app, APP_CMD_DESTROY);
+    while (!android_app->destroyed) {
+        pthread_cond_wait(&android_app->cond, &android_app->mutex);
+    }
+    pthread_mutex_unlock(&android_app->mutex);
+
+    close(android_app->msgread);
+    close(android_app->msgwrite);
+    pthread_cond_destroy(&android_app->cond);
+    pthread_mutex_destroy(&android_app->mutex);
+    free(android_app);
+}
+
+static void onDestroy(ANativeActivity* activity) {
+    LOGV("Destroy: %p\n", activity);
+    android_app_free((struct android_app*)activity->instance);
+}
+
+static void onStart(ANativeActivity* activity) {
+    LOGV("Start: %p\n", activity);
+    android_app_set_activity_state((struct android_app*)activity->instance, APP_CMD_START);
+}
+
+static void onResume(ANativeActivity* activity) {
+    LOGV("Resume: %p\n", activity);
+    android_app_set_activity_state((struct android_app*)activity->instance, APP_CMD_RESUME);
+}
+
+static void* onSaveInstanceState(ANativeActivity* activity, size_t* outLen) {
+    struct android_app* android_app = (struct android_app*)activity->instance;
+    void* savedState = NULL;
+
+    LOGV("SaveInstanceState: %p\n", activity);
+    pthread_mutex_lock(&android_app->mutex);
+    android_app->stateSaved = 0;
+    android_app_write_cmd(android_app, APP_CMD_SAVE_STATE);
+    while (!android_app->stateSaved) {
+        pthread_cond_wait(&android_app->cond, &android_app->mutex);
+    }
+
+    if (android_app->savedState != NULL) {
+        savedState = android_app->savedState;
+        *outLen = android_app->savedStateSize;
+        android_app->savedState = NULL;
+        android_app->savedStateSize = 0;
+    }
+
+    pthread_mutex_unlock(&android_app->mutex);
+
+    return savedState;
+}
+
+static void onPause(ANativeActivity* activity) {
+    LOGV("Pause: %p\n", activity);
+    android_app_set_activity_state((struct android_app*)activity->instance, APP_CMD_PAUSE);
+}
+
+static void onStop(ANativeActivity* activity) {
+    LOGV("Stop: %p\n", activity);
+    android_app_set_activity_state((struct android_app*)activity->instance, APP_CMD_STOP);
+}
+
+static void onConfigurationChanged(ANativeActivity* activity) {
+    struct android_app* android_app = (struct android_app*)activity->instance;
+    LOGV("ConfigurationChanged: %p\n", activity);
+    android_app_write_cmd(android_app, APP_CMD_CONFIG_CHANGED);
+}
+
+static void onLowMemory(ANativeActivity* activity) {
+    struct android_app* android_app = (struct android_app*)activity->instance;
+    LOGV("LowMemory: %p\n", activity);
+    android_app_write_cmd(android_app, APP_CMD_LOW_MEMORY);
+}
+
+static void onWindowFocusChanged(ANativeActivity* activity, int focused) {
+    LOGV("WindowFocusChanged: %p -- %d\n", activity, focused);
+    android_app_write_cmd((struct android_app*)activity->instance,
+            focused ? APP_CMD_GAINED_FOCUS : APP_CMD_LOST_FOCUS);
+}
+
+static void onNativeWindowCreated(ANativeActivity* activity, ANativeWindow* window) {
+    LOGV("NativeWindowCreated: %p -- %p\n", activity, window);
+    android_app_set_window((struct android_app*)activity->instance, window);
+}
+
+static void onNativeWindowDestroyed(ANativeActivity* activity, ANativeWindow* window) {
+    LOGV("NativeWindowDestroyed: %p -- %p\n", activity, window);
+    android_app_set_window((struct android_app*)activity->instance, NULL);
+}
+
+static void onInputQueueCreated(ANativeActivity* activity, AInputQueue* queue) {
+    LOGV("InputQueueCreated: %p -- %p\n", activity, queue);
+    android_app_set_input((struct android_app*)activity->instance, queue);
+}
+
+static void onInputQueueDestroyed(ANativeActivity* activity, AInputQueue* queue) {
+    LOGV("InputQueueDestroyed: %p -- %p\n", activity, queue);
+    android_app_set_input((struct android_app*)activity->instance, NULL);
+}
+
+void ANativeActivity_onCreate(ANativeActivity* activity,
+        void* savedState, size_t savedStateSize) {
+    LOGV("Creating: %p\n", activity);
+    activity->callbacks->onDestroy = onDestroy;
+    activity->callbacks->onStart = onStart;
+    activity->callbacks->onResume = onResume;
+    activity->callbacks->onSaveInstanceState = onSaveInstanceState;
+    activity->callbacks->onPause = onPause;
+    activity->callbacks->onStop = onStop;
+    activity->callbacks->onConfigurationChanged = onConfigurationChanged;
+    activity->callbacks->onLowMemory = onLowMemory;
+    activity->callbacks->onWindowFocusChanged = onWindowFocusChanged;
+    activity->callbacks->onNativeWindowCreated = onNativeWindowCreated;
+    activity->callbacks->onNativeWindowDestroyed = onNativeWindowDestroyed;
+    activity->callbacks->onInputQueueCreated = onInputQueueCreated;
+    activity->callbacks->onInputQueueDestroyed = onInputQueueDestroyed;
+
+    activity->instance = android_app_create(activity, savedState, savedStateSize);
+}

--- a/samples/HelloAndroid/codebase/android_native_app_glue.h
+++ b/samples/HelloAndroid/codebase/android_native_app_glue.h
@@ -1,0 +1,344 @@
+/*
+ * Copyright (C) 2010 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef _ANDROID_NATIVE_APP_GLUE_H
+#define _ANDROID_NATIVE_APP_GLUE_H
+
+#include <poll.h>
+#include <pthread.h>
+#include <sched.h>
+
+#include <android/configuration.h>
+#include <android/looper.h>
+#include <android/native_activity.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * The native activity interface provided by <android/native_activity.h>
+ * is based on a set of application-provided callbacks that will be called
+ * by the Activity's main thread when certain events occur.
+ *
+ * This means that each one of this callbacks _should_ _not_ block, or they
+ * risk having the system force-close the application. This programming
+ * model is direct, lightweight, but constraining.
+ *
+ * The 'threaded_native_app' static library is used to provide a different
+ * execution model where the application can implement its own main event
+ * loop in a different thread instead. Here's how it works:
+ *
+ * 1/ The application must provide a function named "android_main()" that
+ *    will be called when the activity is created, in a new thread that is
+ *    distinct from the activity's main thread.
+ *
+ * 2/ android_main() receives a pointer to a valid "android_app" structure
+ *    that contains references to other important objects, e.g. the
+ *    ANativeActivity obejct instance the application is running in.
+ *
+ * 3/ the "android_app" object holds an ALooper instance that already
+ *    listens to two important things:
+ *
+ *      - activity lifecycle events (e.g. "pause", "resume"). See APP_CMD_XXX
+ *        declarations below.
+ *
+ *      - input events coming from the AInputQueue attached to the activity.
+ *
+ *    Each of these correspond to an ALooper identifier returned by
+ *    ALooper_pollOnce with values of LOOPER_ID_MAIN and LOOPER_ID_INPUT,
+ *    respectively.
+ *
+ *    Your application can use the same ALooper to listen to additional
+ *    file-descriptors.  They can either be callback based, or with return
+ *    identifiers starting with LOOPER_ID_USER.
+ *
+ * 4/ Whenever you receive a LOOPER_ID_MAIN or LOOPER_ID_INPUT event,
+ *    the returned data will point to an android_poll_source structure.  You
+ *    can call the process() function on it, and fill in android_app->onAppCmd
+ *    and android_app->onInputEvent to be called for your own processing
+ *    of the event.
+ *
+ *    Alternatively, you can call the low-level functions to read and process
+ *    the data directly...  look at the process_cmd() and process_input()
+ *    implementations in the glue to see how to do this.
+ *
+ * See the sample named "native-activity" that comes with the NDK with a
+ * full usage example.  Also look at the JavaDoc of NativeActivity.
+ */
+
+struct android_app;
+
+/**
+ * Data associated with an ALooper fd that will be returned as the "outData"
+ * when that source has data ready.
+ */
+struct android_poll_source {
+    // The identifier of this source.  May be LOOPER_ID_MAIN or
+    // LOOPER_ID_INPUT.
+    int32_t id;
+
+    // The android_app this ident is associated with.
+    struct android_app* app;
+
+    // Function to call to perform the standard processing of data from
+    // this source.
+    void (*process)(struct android_app* app, struct android_poll_source* source);
+};
+
+/**
+ * This is the interface for the standard glue code of a threaded
+ * application.  In this model, the application's code is running
+ * in its own thread separate from the main thread of the process.
+ * It is not required that this thread be associated with the Java
+ * VM, although it will need to be in order to make JNI calls any
+ * Java objects.
+ */
+struct android_app {
+    // The application can place a pointer to its own state object
+    // here if it likes.
+    void* userData;
+
+    // Fill this in with the function to process main app commands (APP_CMD_*)
+    void (*onAppCmd)(struct android_app* app, int32_t cmd);
+
+    // Fill this in with the function to process input events.  At this point
+    // the event has already been pre-dispatched, and it will be finished upon
+    // return.  Return 1 if you have handled the event, 0 for any default
+    // dispatching.
+    int32_t (*onInputEvent)(struct android_app* app, AInputEvent* event);
+
+    // The ANativeActivity object instance that this app is running in.
+    ANativeActivity* activity;
+
+    // The current configuration the app is running in.
+    AConfiguration* config;
+
+    // This is the last instance's saved state, as provided at creation time.
+    // It is NULL if there was no state.  You can use this as you need; the
+    // memory will remain around until you call android_app_exec_cmd() for
+    // APP_CMD_RESUME, at which point it will be freed and savedState set to NULL.
+    // These variables should only be changed when processing a APP_CMD_SAVE_STATE,
+    // at which point they will be initialized to NULL and you can malloc your
+    // state and place the information here.  In that case the memory will be
+    // freed for you later.
+    void* savedState;
+    size_t savedStateSize;
+
+    // The ALooper associated with the app's thread.
+    ALooper* looper;
+
+    // When non-NULL, this is the input queue from which the app will
+    // receive user input events.
+    AInputQueue* inputQueue;
+
+    // When non-NULL, this is the window surface that the app can draw in.
+    ANativeWindow* window;
+
+    // Current content rectangle of the window; this is the area where the
+    // window's content should be placed to be seen by the user.
+    ARect contentRect;
+
+    // Current state of the app's activity.  May be either APP_CMD_START,
+    // APP_CMD_RESUME, APP_CMD_PAUSE, or APP_CMD_STOP; see below.
+    int activityState;
+
+    // This is non-zero when the application's NativeActivity is being
+    // destroyed and waiting for the app thread to complete.
+    int destroyRequested;
+
+    // -------------------------------------------------
+    // Below are "private" implementation of the glue code.
+
+    pthread_mutex_t mutex;
+    pthread_cond_t cond;
+
+    int msgread;
+    int msgwrite;
+
+    pthread_t thread;
+
+    struct android_poll_source cmdPollSource;
+    struct android_poll_source inputPollSource;
+
+    int running;
+    int stateSaved;
+    int destroyed;
+    int redrawNeeded;
+    AInputQueue* pendingInputQueue;
+    ANativeWindow* pendingWindow;
+    ARect pendingContentRect;
+};
+
+enum {
+    /**
+     * Looper data ID of commands coming from the app's main thread, which
+     * is returned as an identifier from ALooper_pollOnce().  The data for this
+     * identifier is a pointer to an android_poll_source structure.
+     * These can be retrieved and processed with android_app_read_cmd()
+     * and android_app_exec_cmd().
+     */
+    LOOPER_ID_MAIN = 1,
+
+    /**
+     * Looper data ID of events coming from the AInputQueue of the
+     * application's window, which is returned as an identifier from
+     * ALooper_pollOnce().  The data for this identifier is a pointer to an
+     * android_poll_source structure.  These can be read via the inputQueue
+     * object of android_app.
+     */
+    LOOPER_ID_INPUT = 2,
+
+    /**
+     * Start of user-defined ALooper identifiers.
+     */
+    LOOPER_ID_USER = 3,
+};
+
+enum {
+    /**
+     * Command from main thread: the AInputQueue has changed.  Upon processing
+     * this command, android_app->inputQueue will be updated to the new queue
+     * (or NULL).
+     */
+    APP_CMD_INPUT_CHANGED,
+
+    /**
+     * Command from main thread: a new ANativeWindow is ready for use.  Upon
+     * receiving this command, android_app->window will contain the new window
+     * surface.
+     */
+    APP_CMD_INIT_WINDOW,
+
+    /**
+     * Command from main thread: the existing ANativeWindow needs to be
+     * terminated.  Upon receiving this command, android_app->window still
+     * contains the existing window; after calling android_app_exec_cmd
+     * it will be set to NULL.
+     */
+    APP_CMD_TERM_WINDOW,
+
+    /**
+     * Command from main thread: the current ANativeWindow has been resized.
+     * Please redraw with its new size.
+     */
+    APP_CMD_WINDOW_RESIZED,
+
+    /**
+     * Command from main thread: the system needs that the current ANativeWindow
+     * be redrawn.  You should redraw the window before handing this to
+     * android_app_exec_cmd() in order to avoid transient drawing glitches.
+     */
+    APP_CMD_WINDOW_REDRAW_NEEDED,
+
+    /**
+     * Command from main thread: the content area of the window has changed,
+     * such as from the soft input window being shown or hidden.  You can
+     * find the new content rect in android_app::contentRect.
+     */
+    APP_CMD_CONTENT_RECT_CHANGED,
+
+    /**
+     * Command from main thread: the app's activity window has gained
+     * input focus.
+     */
+    APP_CMD_GAINED_FOCUS,
+
+    /**
+     * Command from main thread: the app's activity window has lost
+     * input focus.
+     */
+    APP_CMD_LOST_FOCUS,
+
+    /**
+     * Command from main thread: the current device configuration has changed.
+     */
+    APP_CMD_CONFIG_CHANGED,
+
+    /**
+     * Command from main thread: the system is running low on memory.
+     * Try to reduce your memory use.
+     */
+    APP_CMD_LOW_MEMORY,
+
+    /**
+     * Command from main thread: the app's activity has been started.
+     */
+    APP_CMD_START,
+
+    /**
+     * Command from main thread: the app's activity has been resumed.
+     */
+    APP_CMD_RESUME,
+
+    /**
+     * Command from main thread: the app should generate a new saved state
+     * for itself, to restore from later if needed.  If you have saved state,
+     * allocate it with malloc and place it in android_app.savedState with
+     * the size in android_app.savedStateSize.  The will be freed for you
+     * later.
+     */
+    APP_CMD_SAVE_STATE,
+
+    /**
+     * Command from main thread: the app's activity has been paused.
+     */
+    APP_CMD_PAUSE,
+
+    /**
+     * Command from main thread: the app's activity has been stopped.
+     */
+    APP_CMD_STOP,
+
+    /**
+     * Command from main thread: the app's activity is being destroyed,
+     * and waiting for the app thread to clean up and exit before proceeding.
+     */
+    APP_CMD_DESTROY,
+};
+
+/**
+ * Call when ALooper_pollAll() returns LOOPER_ID_MAIN, reading the next
+ * app command message.
+ */
+int8_t android_app_read_cmd(struct android_app* android_app);
+
+/**
+ * Call with the command returned by android_app_read_cmd() to do the
+ * initial pre-processing of the given command.  You can perform your own
+ * actions for the command after calling this function.
+ */
+void android_app_pre_exec_cmd(struct android_app* android_app, int8_t cmd);
+
+/**
+ * Call with the command returned by android_app_read_cmd() to do the
+ * final post-processing of the given command.  You must have done your own
+ * actions for the command before calling this function.
+ */
+void android_app_post_exec_cmd(struct android_app* android_app, int8_t cmd);
+
+/**
+ * This is the function that application code must implement, representing
+ * the main entry to the app.
+ */
+extern void android_main(struct android_app* app);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _ANDROID_NATIVE_APP_GLUE_H */

--- a/samples/HelloAndroid/codebase/main.cpp
+++ b/samples/HelloAndroid/codebase/main.cpp
@@ -1,0 +1,297 @@
+/*
+* Copyright (C) 2010 The Android Open Source Project
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
+
+#include "pch.h"
+#include "Cube.h"
+#include <cstddef>
+
+#define LOGI(...) ((void)__android_log_print(ANDROID_LOG_INFO, "AndroidProject1.NativeActivity", __VA_ARGS__))
+#define LOGW(...) ((void)__android_log_print(ANDROID_LOG_WARN, "AndroidProject1.NativeActivity", __VA_ARGS__))
+
+/**
+* Our saved state data.
+*/
+struct saved_state {
+	float angle;
+	int32_t x;
+	int32_t y;
+};
+
+/**
+* Shared state for our app.
+*/
+struct engine {
+	struct android_app* app;
+
+	ASensorManager* sensorManager;
+	const ASensor* accelerometerSensor;
+	ASensorEventQueue* sensorEventQueue;
+
+	int animating;
+	EGLDisplay display;
+	EGLSurface surface;
+	EGLContext context;
+	int32_t width;
+	int32_t height;
+	struct saved_state state;
+};
+
+/**
+* Initialize an EGL context for the current display.
+*/
+static int engine_init_display(struct engine* engine) {
+	// initialize OpenGL ES and EGL
+
+	/*
+	* Here specify the attributes of the desired configuration.
+	* Below, we select an EGLConfig with at least 8 bits per color
+	* component compatible with on-screen windows
+	*/
+	const EGLint attribs[] = {
+		EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
+		EGL_BLUE_SIZE, 8,
+		EGL_GREEN_SIZE, 8,
+		EGL_RED_SIZE, 8,
+		EGL_NONE
+	};
+	EGLint w, h, format;
+	EGLint numConfigs;
+	EGLConfig config;
+	EGLSurface surface;
+	EGLContext context;
+
+	EGLDisplay display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
+
+	eglInitialize(display, 0, 0);
+
+	/* Here, the application chooses the configuration it desires. In this
+	* sample, we have a very simplified selection process, where we pick
+	* the first EGLConfig that matches our criteria */
+	eglChooseConfig(display, attribs, &config, 1, &numConfigs);
+
+	/* EGL_NATIVE_VISUAL_ID is an attribute of the EGLConfig that is
+	* guaranteed to be accepted by ANativeWindow_setBuffersGeometry().
+	* As soon as we picked a EGLConfig, we can safely reconfigure the
+	* ANativeWindow buffers to match, using EGL_NATIVE_VISUAL_ID. */
+	eglGetConfigAttrib(display, config, EGL_NATIVE_VISUAL_ID, &format);
+
+	ANativeWindow_setBuffersGeometry(engine->app->window, 0, 0, format);
+
+	surface = eglCreateWindowSurface(display, config, engine->app->window, NULL);
+	context = eglCreateContext(display, config, NULL, NULL);
+
+	if (eglMakeCurrent(display, surface, surface, context) == EGL_FALSE) {
+		LOGW("Unable to eglMakeCurrent");
+		return -1;
+	}
+
+	eglQuerySurface(display, surface, EGL_WIDTH, &w);
+	eglQuerySurface(display, surface, EGL_HEIGHT, &h);
+
+	engine->display = display;
+	engine->context = context;
+	engine->surface = surface;
+	engine->width = w;
+	engine->height = h;
+	engine->state.angle = 0;
+
+	// Initialize GL state.
+	Cube_setupGL(w, h);
+
+	return 0;
+}
+
+/**
+* Just the current frame in the display.
+*/
+
+static void engine_draw_frame(struct engine* engine) {
+	if (engine->display == NULL) {
+		// No display.
+		return;
+	}
+
+	Cube_prepare();
+
+	Cube_draw();
+
+	eglSwapBuffers(engine->display, engine->surface);
+}
+
+
+/**
+* Tear down the EGL context currently associated with the display.
+*/
+static void engine_term_display(struct engine* engine) {
+	if (engine->display != EGL_NO_DISPLAY) {
+		eglMakeCurrent(engine->display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+		if (engine->context != EGL_NO_CONTEXT) {
+			eglDestroyContext(engine->display, engine->context);
+		}
+		if (engine->surface != EGL_NO_SURFACE) {
+			eglDestroySurface(engine->display, engine->surface);
+		}
+		eglTerminate(engine->display);
+	}
+	engine->animating = 0;
+	engine->display = EGL_NO_DISPLAY;
+	engine->context = EGL_NO_CONTEXT;
+	engine->surface = EGL_NO_SURFACE;
+
+	Cube_tearDownGL();
+}
+
+/**
+* Process the next input event.
+*/
+static int32_t engine_handle_input(struct android_app* app, AInputEvent* event) {
+	struct engine* engine = (struct engine*)app->userData;
+	if (AInputEvent_getType(event) == AINPUT_EVENT_TYPE_MOTION) {
+		engine->state.x = AMotionEvent_getX(event, 0);
+		engine->state.y = AMotionEvent_getY(event, 0);
+		return 1;
+	}
+	return 0;
+}
+
+/**
+* Process the next main command.
+*/
+static void engine_handle_cmd(struct android_app* app, int32_t cmd) {
+	struct engine* engine = (struct engine*)app->userData;
+	switch (cmd) {
+	case APP_CMD_SAVE_STATE:
+		// The system has asked us to save our current state.  Do so.
+		engine->app->savedState = malloc(sizeof(struct saved_state));
+		*((struct saved_state*)engine->app->savedState) = engine->state;
+		engine->app->savedStateSize = sizeof(struct saved_state);
+		break;
+	case APP_CMD_INIT_WINDOW:
+		// The window is being shown, get it ready.
+		if (engine->app->window != NULL) {
+			engine_init_display(engine);
+			engine_draw_frame(engine);
+		}
+		break;
+	case APP_CMD_TERM_WINDOW:
+		// The window is being hidden or closed, clean it up.
+		engine_term_display(engine);
+		break;
+	case APP_CMD_GAINED_FOCUS:
+		// When our app gains focus, we start monitoring the accelerometer.
+		if (engine->accelerometerSensor != NULL) {
+			ASensorEventQueue_enableSensor(engine->sensorEventQueue,
+				engine->accelerometerSensor);
+			// We'd like to get 60 events per second (in us).
+			ASensorEventQueue_setEventRate(engine->sensorEventQueue,
+				engine->accelerometerSensor, (1000L / 60) * 1000);
+		}
+		break;
+	case APP_CMD_LOST_FOCUS:
+		// When our app loses focus, we stop monitoring the accelerometer.
+		// This is to avoid consuming battery while not being used.
+		if (engine->accelerometerSensor != NULL) {
+			ASensorEventQueue_disableSensor(engine->sensorEventQueue,
+				engine->accelerometerSensor);
+		}
+		// Also stop animating.
+		engine->animating = 0;
+		engine_draw_frame(engine);
+		break;
+	}
+}
+
+/**
+* This is the main entry point of a native application that is using
+* android_native_app_glue.  It runs in its own thread, with its own
+* event loop for receiving input events and doing other things.
+*/
+void android_main(struct android_app* state) {
+	struct engine engine;
+
+	memset(&engine, 0, sizeof(engine));
+	state->userData = &engine;
+	state->onAppCmd = engine_handle_cmd;
+	state->onInputEvent = engine_handle_input;
+	engine.app = state;
+
+	// Prepare to monitor accelerometer
+	engine.sensorManager = ASensorManager_getInstance();
+	engine.accelerometerSensor = ASensorManager_getDefaultSensor(engine.sensorManager,
+		ASENSOR_TYPE_ACCELEROMETER);
+	engine.sensorEventQueue = ASensorManager_createEventQueue(engine.sensorManager,
+		state->looper, LOOPER_ID_USER, NULL, NULL);
+
+	if (state->savedState != NULL) {
+		// We are starting with a previous saved state; restore from it.
+		engine.state = *(struct saved_state*)state->savedState;
+	}
+
+	engine.animating = 1;
+
+	// loop waiting for stuff to do.
+
+	while (1) {
+		// Read all pending events.
+		int ident;
+		int events;
+		struct android_poll_source* source;
+
+		// If not animating, we will block forever waiting for events.
+		// If animating, we loop until all events are read, then continue
+		// to draw the next frame of animation.
+		while ((ident = ALooper_pollAll(engine.animating ? 0 : -1, NULL, &events,
+			(void**)&source)) >= 0) {
+
+			// Process this event.
+			if (source != NULL) {
+				source->process(state, source);
+			}
+
+			// If a sensor has data, process it now.
+			if (ident == LOOPER_ID_USER) {
+				if (engine.accelerometerSensor != NULL) {
+					ASensorEvent event;
+					while (ASensorEventQueue_getEvents(engine.sensorEventQueue,
+						&event, 1) > 0) {
+						LOGI("accelerometer: x=%f y=%f z=%f",
+							event.acceleration.x, event.acceleration.y,
+							event.acceleration.z);
+					}
+				}
+			}
+
+			// Check if we are exiting.
+			if (state->destroyRequested != 0) {
+				engine_term_display(&engine);
+				return;
+			}
+		}
+
+		if (engine.animating) {
+			// Done with events; draw next animation frame.
+			Cube_update();
+			//if (engine.state.angle > 1) {
+			//	engine.state.angle = 0;
+			//}
+
+			// Drawing is throttled to the screen update rate, so there
+			// is no need to do timing here.
+			engine_draw_frame(&engine);
+		}
+	}
+}

--- a/samples/HelloAndroid/codebase/pch.h
+++ b/samples/HelloAndroid/codebase/pch.h
@@ -1,0 +1,24 @@
+//
+// pch.h
+// Header for standard system include files.
+//
+// Used by the build system to generate the precompiled header. Note that no
+// pch.cpp is needed and the pch.h is automatically included in all cpp files
+// that are part of the project
+//
+
+#include <jni.h>
+#include <errno.h>
+
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/resource.h>
+
+#include <EGL/egl.h>
+#include <GLES/gl.h>
+
+#include <android/sensor.h>
+
+#include <android/log.h>
+#include "android_native_app_glue.h"

--- a/samples/HelloAndroid/package/AndroidManifest.xml
+++ b/samples/HelloAndroid/package/AndroidManifest.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Changes made to Package Name should also be reflected in the Debugging - Package Name property, in the Property Pages -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="com.$(ApplicationName)"
+        android:versionCode="1"
+        android:versionName="1.0">
+
+    <!-- This is the platform API where NativeActivity was introduced. -->
+    <uses-sdk android:minSdkVersion="9" android:targetSdkVersion="21"/>
+
+    <!-- This .apk has no Java code itself, so set hasCode to false. -->
+    <application android:label="@string/app_name" android:hasCode="false">
+
+        <!-- Our activity is the built-in NativeActivity framework class.
+             This will take care of integrating with our NDK code. -->
+        <activity android:name="android.app.NativeActivity"
+                android:label="@string/app_name"
+                android:configChanges="orientation|keyboardHidden">
+            <!-- Tell NativeActivity the name of our .so -->
+            <meta-data android:name="android.app.lib_name"
+                    android:value="$(AndroidAppLibName)" />
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/samples/HelloAndroid/package/build.xml
+++ b/samples/HelloAndroid/package/build.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="$(projectname)" default="help">
+
+    <!-- The ant.properties file can be created by you. It is only edited by the
+         'android' tool to add properties to it.
+         This is the place to change some Ant specific build properties.
+         Here are some properties you may want to change/update:
+
+         source.dir
+             The name of the source directory. Default is 'src'.
+         out.dir
+             The name of the output directory. Default is 'bin'.
+
+         For other overridable properties, look at the beginning of the rules
+         files in the SDK, at tools/ant/build.xml
+
+         Properties related to the SDK location or the project target should
+         be updated using the 'android' tool with the 'update' action.
+
+         This file is an integral part of the build system for your
+         application and should be checked into Version Control Systems.
+
+         -->
+    <property file="ant.properties" />
+
+    <!-- if sdk.dir was not set from one of the property file, then
+         get it from the ANDROID_HOME env var. -->
+    <property environment="env" />
+    <condition property="sdk.dir" value="${env.ANDROID_HOME}">
+        <isset property="env.ANDROID_HOME" />
+    </condition>
+
+    <!-- The project.properties file contains project specific properties such as
+         project target, and library dependencies. Lower level build properties are
+         stored in ant.properties
+
+         This file is an integral part of the build system for your
+         application and should be checked into Version Control Systems. -->
+    <loadproperties srcFile="project.properties" />
+
+    <!-- quick check on sdk.dir -->
+    <fail
+            message="sdk.dir is missing. Make sure ANDROID_HOME environment variable is correctly set."
+            unless="sdk.dir"
+    />
+
+    <!--
+        Import per project custom build rules if present at the root of the project.
+        This is the place to put custom intermediary targets such as:
+            -pre-build
+            -pre-compile
+            -post-compile (This is typically used for code obfuscation.
+                           Compiled code location: ${out.classes.absolute.dir}
+                           If this is not done in place, override ${out.dex.input.absolute.dir})
+            -post-package
+            -post-build
+            -pre-clean
+    -->
+    <import file="custom_rules.xml" optional="true" />
+
+    <!-- Import the actual build file.
+
+         To customize existing targets, there are two options:
+         - Customize only one target:
+             - copy/paste the target into this file, *before* the
+               <import> task.
+             - customize it to your needs.
+         - Customize the whole content of build.xml
+             - copy/paste the content of the rules files (minus the top node)
+               into this file, replacing the <import> task.
+             - customize to your needs.
+
+         ***********************
+         ****** IMPORTANT ******
+         ***********************
+         In all cases you must update the value of version-tag below to read 'custom' instead of an integer,
+         in order to avoid having your file be overridden by tools such as "android update project"
+    -->
+    <!-- version-tag: 1 -->
+    <import file="${sdk.dir}/tools/ant/build.xml" />
+
+    <target name="-pre-compile">
+      <path id="project.all.jars.path">
+        <path path="${toString:project.all.jars.path}"/>
+        <fileset dir="${jar.libs.dir}">
+          <include name="*.jar"/>
+        </fileset>
+      </path>
+    </target>
+</project>

--- a/samples/HelloAndroid/package/project.properties
+++ b/samples/HelloAndroid/package/project.properties
@@ -1,0 +1,3 @@
+# Project target
+target=$(androidapilevel)
+# Provide path to the directory where prebuilt external jar files are by setting jar.libs.dir=

--- a/samples/HelloAndroid/package/res/values/strings.xml
+++ b/samples/HelloAndroid/package/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">OpenGLESApp1.Android.Packaging</string>
+</resources>

--- a/samples/HelloAndroid/reference/package/helloandroidpackage.vs2017.androidproj
+++ b/samples/HelloAndroid/reference/package/helloandroidpackage.vs2017.androidproj
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|ARM">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x86">
+      <Configuration>Debug</Configuration>
+      <Platform>x86</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM">
+      <Configuration>Release</Configuration>
+      <Platform>ARM</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x86">
+      <Configuration>Release</Configuration>
+      <Platform>x86</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{44BE5231-74B6-343D-B76A-F1455D73AEA1}</ProjectGuid>
+    <RootNamespace>HelloAndroidPackage</RootNamespace>
+    <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
+    <ProjectVersion>1.0</ProjectVersion>
+    <ProjectName>HelloAndroidPackage</ProjectName>
+  </PropertyGroup>
+  <PropertyGroup Label="Globals" Condition="'$(Platform)'=='ARM64' Or '$(Platform)'=='x64' Or '$(Platform)'=='ARM' Or '$(Platform)'=='x86'">
+    <ApplicationType>Android</ApplicationType>
+    <ApplicationTypeRevision>3.0</ApplicationTypeRevision>
+  </PropertyGroup>
+  <Import Project="$(AndroidTargetsPath)\Android.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <AndroidAPILevel>android-21</AndroidAPILevel>
+    <OutDir>$(ProjectDir)output\android\debug\</OutDir>
+    <IntDir>temp\vs2017\android\armeabi_v7a_noblob_msbuild_vs2017_v3_5_debug_lib_android\</IntDir>
+    <TargetName>helloandroidpackage</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <AndroidAPILevel>android-21</AndroidAPILevel>
+    <OutDir>$(ProjectDir)output\android\debug\</OutDir>
+    <IntDir>temp\vs2017\android\arm64_v8a_noblob_msbuild_vs2017_v3_5_debug_lib_android\</IntDir>
+    <TargetName>helloandroidpackage</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <AndroidAPILevel>android-21</AndroidAPILevel>
+    <OutDir>$(ProjectDir)output\android\debug\</OutDir>
+    <IntDir>temp\vs2017\android\x86_64_noblob_msbuild_vs2017_v3_5_debug_lib_android\</IntDir>
+    <TargetName>helloandroidpackage</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <AndroidAPILevel>android-21</AndroidAPILevel>
+    <OutDir>$(ProjectDir)output\android\debug\</OutDir>
+    <IntDir>temp\vs2017\android\x86_noblob_msbuild_vs2017_v3_5_debug_lib_android\</IntDir>
+    <TargetName>helloandroidpackage</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <AndroidAPILevel>android-21</AndroidAPILevel>
+    <OutDir>$(ProjectDir)output\android\release\</OutDir>
+    <IntDir>temp\vs2017\android\armeabi_v7a_noblob_msbuild_vs2017_v3_5_release_lib_android\</IntDir>
+    <TargetName>helloandroidpackage</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <AndroidAPILevel>android-21</AndroidAPILevel>
+    <OutDir>$(ProjectDir)output\android\release\</OutDir>
+    <IntDir>temp\vs2017\android\arm64_v8a_noblob_msbuild_vs2017_v3_5_release_lib_android\</IntDir>
+    <TargetName>helloandroidpackage</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <AndroidAPILevel>android-21</AndroidAPILevel>
+    <OutDir>$(ProjectDir)output\android\release\</OutDir>
+    <IntDir>temp\vs2017\android\x86_64_noblob_msbuild_vs2017_v3_5_release_lib_android\</IntDir>
+    <TargetName>helloandroidpackage</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <AndroidAPILevel>android-21</AndroidAPILevel>
+    <OutDir>$(ProjectDir)output\android\release\</OutDir>
+    <IntDir>temp\vs2017\android\x86_noblob_msbuild_vs2017_v3_5_release_lib_android\</IntDir>
+    <TargetName>helloandroidpackage</TargetName>
+  </PropertyGroup>
+  <Import Project="$(AndroidTargetsPath)\Android.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+    <ImportGroup Label="Shared" />
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+    <AntPackage>
+      <WorkingDirectory>$(OutDir)Package\</WorkingDirectory>
+      <AndroidAppLibName>helloandroidproject</AndroidAppLibName>
+    </AntPackage>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <AntPackage>
+      <WorkingDirectory>$(OutDir)Package\</WorkingDirectory>
+      <AndroidAppLibName>helloandroidproject</AndroidAppLibName>
+    </AntPackage>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <AntPackage>
+      <WorkingDirectory>$(OutDir)Package\</WorkingDirectory>
+      <AndroidAppLibName>helloandroidproject</AndroidAppLibName>
+    </AntPackage>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
+    <AntPackage>
+      <WorkingDirectory>$(OutDir)Package\</WorkingDirectory>
+      <AndroidAppLibName>helloandroidproject</AndroidAppLibName>
+    </AntPackage>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+    <AntPackage>
+      <WorkingDirectory>$(OutDir)Package\</WorkingDirectory>
+      <AndroidAppLibName>helloandroidproject</AndroidAppLibName>
+    </AntPackage>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <AntPackage>
+      <WorkingDirectory>$(OutDir)Package\</WorkingDirectory>
+      <AndroidAppLibName>helloandroidproject</AndroidAppLibName>
+    </AntPackage>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <AntPackage>
+      <WorkingDirectory>$(OutDir)Package\</WorkingDirectory>
+      <AndroidAppLibName>helloandroidproject</AndroidAppLibName>
+    </AntPackage>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'">
+    <AntPackage>
+      <WorkingDirectory>$(OutDir)Package\</WorkingDirectory>
+      <AndroidAppLibName>helloandroidproject</AndroidAppLibName>
+    </AntPackage>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+  </ItemGroup>
+  <ItemGroup>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="AndroidManifest.xml" />
+    <Content Include="build.xml" />
+    <Content Include="output\android\debug\Package\AndroidManifest.xml" />
+    <Content Include="output\android\debug\Package\bin\AndroidManifest.xml" />
+    <Content Include="output\android\debug\Package\build.xml" />
+    <Content Include="output\android\debug\Package\res\values\strings.xml" />
+    <Content Include="res\values\strings.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <AntBuildXml Include="build.xml" />
+    <AndroidManifest Include="AndroidManifest.xml" />
+    <AntProjectPropertiesFile Include="project.properties" />
+  </ItemGroup>
+  <Import Project="$(AndroidTargetsPath)\Android.targets" />
+  <ImportGroup Label="ExtensionTargets" />
+  <ItemGroup>
+    <ProjectReference Include="..\projects\helloandroidproject.vs2017.vcxproj">
+      <Project>{3FD58462-F800-5DB7-045F-8BA177D066EC}</Project>
+    </ProjectReference>
+  </ItemGroup>
+</Project>

--- a/samples/HelloAndroid/reference/projects/helloandroid.vs2017.sln
+++ b/samples/HelloAndroid/reference/projects/helloandroid.vs2017.sln
@@ -1,0 +1,63 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+Project("{EAAC564B-F271-4B9C-99B6-F18BE0B11958}") = "HelloAndroidPackage", "..\package\helloandroidpackage.vs2017.androidproj", "{44BE5231-74B6-343D-B76A-F1455D73AEA1}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "HelloAndroidProject", "helloandroidproject.vs2017.vcxproj", "{3FD58462-F800-5DB7-045F-8BA177D066EC}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|ARM = Debug|ARM
+		Debug|ARM64 = Debug|ARM64
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|ARM = Release|ARM
+		Release|ARM64 = Release|ARM64
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{44BE5231-74B6-343D-B76A-F1455D73AEA1}.Debug|ARM.ActiveCfg = Debug|ARM
+		{44BE5231-74B6-343D-B76A-F1455D73AEA1}.Debug|ARM.Build.0 = Debug|ARM
+		{44BE5231-74B6-343D-B76A-F1455D73AEA1}.Debug|ARM.Deploy.0 = Debug|ARM
+		{44BE5231-74B6-343D-B76A-F1455D73AEA1}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{44BE5231-74B6-343D-B76A-F1455D73AEA1}.Debug|ARM64.Build.0 = Debug|ARM64
+		{44BE5231-74B6-343D-B76A-F1455D73AEA1}.Debug|ARM64.Deploy.0 = Debug|ARM64
+		{44BE5231-74B6-343D-B76A-F1455D73AEA1}.Debug|x64.ActiveCfg = Debug|x64
+		{44BE5231-74B6-343D-B76A-F1455D73AEA1}.Debug|x64.Build.0 = Debug|x64
+		{44BE5231-74B6-343D-B76A-F1455D73AEA1}.Debug|x64.Deploy.0 = Debug|x64
+		{44BE5231-74B6-343D-B76A-F1455D73AEA1}.Debug|x86.ActiveCfg = Debug|x86
+		{44BE5231-74B6-343D-B76A-F1455D73AEA1}.Debug|x86.Build.0 = Debug|x86
+		{44BE5231-74B6-343D-B76A-F1455D73AEA1}.Debug|x86.Deploy.0 = Debug|x86
+		{44BE5231-74B6-343D-B76A-F1455D73AEA1}.Release|ARM.ActiveCfg = Release|ARM
+		{44BE5231-74B6-343D-B76A-F1455D73AEA1}.Release|ARM.Build.0 = Release|ARM
+		{44BE5231-74B6-343D-B76A-F1455D73AEA1}.Release|ARM.Deploy.0 = Release|ARM
+		{44BE5231-74B6-343D-B76A-F1455D73AEA1}.Release|ARM64.ActiveCfg = Release|ARM64
+		{44BE5231-74B6-343D-B76A-F1455D73AEA1}.Release|ARM64.Build.0 = Release|ARM64
+		{44BE5231-74B6-343D-B76A-F1455D73AEA1}.Release|ARM64.Deploy.0 = Release|ARM64
+		{44BE5231-74B6-343D-B76A-F1455D73AEA1}.Release|x64.ActiveCfg = Release|x64
+		{44BE5231-74B6-343D-B76A-F1455D73AEA1}.Release|x64.Build.0 = Release|x64
+		{44BE5231-74B6-343D-B76A-F1455D73AEA1}.Release|x64.Deploy.0 = Release|x64
+		{44BE5231-74B6-343D-B76A-F1455D73AEA1}.Release|x86.ActiveCfg = Release|x86
+		{44BE5231-74B6-343D-B76A-F1455D73AEA1}.Release|x86.Build.0 = Release|x86
+		{44BE5231-74B6-343D-B76A-F1455D73AEA1}.Release|x86.Deploy.0 = Release|x86
+		{3FD58462-F800-5DB7-045F-8BA177D066EC}.Debug|ARM.ActiveCfg = Debug|ARM
+		{3FD58462-F800-5DB7-045F-8BA177D066EC}.Debug|ARM.Build.0 = Debug|ARM
+		{3FD58462-F800-5DB7-045F-8BA177D066EC}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{3FD58462-F800-5DB7-045F-8BA177D066EC}.Debug|ARM64.Build.0 = Debug|ARM64
+		{3FD58462-F800-5DB7-045F-8BA177D066EC}.Debug|x64.ActiveCfg = Debug|x64
+		{3FD58462-F800-5DB7-045F-8BA177D066EC}.Debug|x64.Build.0 = Debug|x64
+		{3FD58462-F800-5DB7-045F-8BA177D066EC}.Debug|x86.ActiveCfg = Debug|x86
+		{3FD58462-F800-5DB7-045F-8BA177D066EC}.Debug|x86.Build.0 = Debug|x86
+		{3FD58462-F800-5DB7-045F-8BA177D066EC}.Release|ARM.ActiveCfg = Release|ARM
+		{3FD58462-F800-5DB7-045F-8BA177D066EC}.Release|ARM.Build.0 = Release|ARM
+		{3FD58462-F800-5DB7-045F-8BA177D066EC}.Release|ARM64.ActiveCfg = Release|ARM64
+		{3FD58462-F800-5DB7-045F-8BA177D066EC}.Release|ARM64.Build.0 = Release|ARM64
+		{3FD58462-F800-5DB7-045F-8BA177D066EC}.Release|x64.ActiveCfg = Release|x64
+		{3FD58462-F800-5DB7-045F-8BA177D066EC}.Release|x64.Build.0 = Release|x64
+		{3FD58462-F800-5DB7-045F-8BA177D066EC}.Release|x86.ActiveCfg = Release|x86
+		{3FD58462-F800-5DB7-045F-8BA177D066EC}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/samples/HelloAndroid/reference/projects/helloandroidproject.vs2017.vcxproj
+++ b/samples/HelloAndroid/reference/projects/helloandroidproject.vs2017.vcxproj
@@ -1,0 +1,439 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|ARM">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x86">
+      <Configuration>Debug</Configuration>
+      <Platform>x86</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM">
+      <Configuration>Release</Configuration>
+      <Platform>ARM</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x86">
+      <Configuration>Release</Configuration>
+      <Platform>x86</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{3FD58462-F800-5DB7-045F-8BA177D066EC}</ProjectGuid>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <RootNamespace>HelloAndroidProject</RootNamespace>
+    <ProjectName>HelloAndroidProject</ProjectName>
+  </PropertyGroup>
+  <PropertyGroup Label="Globals" Condition="'$(Platform)'=='ARM64' Or '$(Platform)'=='x64' Or '$(Platform)'=='ARM' Or '$(Platform)'=='x86'">
+    <ApplicationType>Android</ApplicationType>
+    <ApplicationTypeRevision>3.0</ApplicationTypeRevision>
+  </PropertyGroup>
+  <PropertyGroup Label="Globals">
+    <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <UseOfStl>gnustl_static</UseOfStl>
+    <ThumbMode>Disabled</ThumbMode>
+    <AndroidAPILevel>android-21</AndroidAPILevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <UseOfStl>gnustl_static</UseOfStl>
+    <ThumbMode>Disabled</ThumbMode>
+    <AndroidAPILevel>android-21</AndroidAPILevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <UseOfStl>gnustl_static</UseOfStl>
+    <ThumbMode>Disabled</ThumbMode>
+    <AndroidAPILevel>android-21</AndroidAPILevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <UseOfStl>gnustl_static</UseOfStl>
+    <ThumbMode>Disabled</ThumbMode>
+    <AndroidAPILevel>android-21</AndroidAPILevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <UseOfStl>gnustl_static</UseOfStl>
+    <ThumbMode>Disabled</ThumbMode>
+    <AndroidAPILevel>android-21</AndroidAPILevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <UseOfStl>gnustl_static</UseOfStl>
+    <ThumbMode>Disabled</ThumbMode>
+    <AndroidAPILevel>android-21</AndroidAPILevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <UseOfStl>gnustl_static</UseOfStl>
+    <ThumbMode>Disabled</ThumbMode>
+    <AndroidAPILevel>android-21</AndroidAPILevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <UseOfStl>gnustl_static</UseOfStl>
+    <ThumbMode>Disabled</ThumbMode>
+    <AndroidAPILevel>android-21</AndroidAPILevel>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+    <TargetName>libhelloandroidproject</TargetName>
+    <OutDir>$(ProjectDir)output\android\debug\</OutDir>
+    <IntDir>temp\vs2017\android\armeabi_v7a_noblob_msbuild_vs2017_v3_5_debug_lib_android\</IntDir>
+    <TargetExt>.so</TargetExt>
+    <OutputFile>output\android\debug\libhelloandroidproject.so</OutputFile>
+    <IncludePath>$(StlIncludeDirectories);$(VS_NdkRoot)\sources\android;$(VS_NdkRoot)\sysroot\usr\include;$(VS_NdkRoot)\sysroot\usr\include\arm-linux-androideabi</IncludePath>
+    <UseMultiToolTask>true</UseMultiToolTask>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <TargetName>libhelloandroidproject</TargetName>
+    <OutDir>$(ProjectDir)output\android\debug\</OutDir>
+    <IntDir>temp\vs2017\android\arm64_v8a_noblob_msbuild_vs2017_v3_5_debug_lib_android\</IntDir>
+    <TargetExt>.so</TargetExt>
+    <OutputFile>output\android\debug\libhelloandroidproject.so</OutputFile>
+    <IncludePath>$(StlIncludeDirectories);$(VS_NdkRoot)\sources\android;$(VS_NdkRoot)\sysroot\usr\include;$(VS_NdkRoot)\sysroot\usr\include\aarch64-linux-android</IncludePath>
+    <UseMultiToolTask>true</UseMultiToolTask>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <TargetName>libhelloandroidproject</TargetName>
+    <OutDir>$(ProjectDir)output\android\debug\</OutDir>
+    <IntDir>temp\vs2017\android\x86_64_noblob_msbuild_vs2017_v3_5_debug_lib_android\</IntDir>
+    <TargetExt>.so</TargetExt>
+    <OutputFile>output\android\debug\libhelloandroidproject.so</OutputFile>
+    <IncludePath>$(StlIncludeDirectories);$(VS_NdkRoot)\sources\android;$(VS_NdkRoot)\sysroot\usr\include;$(VS_NdkRoot)\sysroot\usr\include\x86_64-linux-android</IncludePath>
+    <UseMultiToolTask>true</UseMultiToolTask>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
+    <TargetName>libhelloandroidproject</TargetName>
+    <OutDir>$(ProjectDir)output\android\debug\</OutDir>
+    <IntDir>temp\vs2017\android\x86_noblob_msbuild_vs2017_v3_5_debug_lib_android\</IntDir>
+    <TargetExt>.so</TargetExt>
+    <OutputFile>output\android\debug\libhelloandroidproject.so</OutputFile>
+    <IncludePath>$(StlIncludeDirectories);$(VS_NdkRoot)\sources\android;$(VS_NdkRoot)\sysroot\usr\include;$(VS_NdkRoot)\sysroot\usr\include\i686-linux-android</IncludePath>
+    <UseMultiToolTask>true</UseMultiToolTask>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+    <TargetName>libhelloandroidproject</TargetName>
+    <OutDir>$(ProjectDir)output\android\release\</OutDir>
+    <IntDir>temp\vs2017\android\armeabi_v7a_noblob_msbuild_vs2017_v3_5_release_lib_android\</IntDir>
+    <TargetExt>.so</TargetExt>
+    <OutputFile>output\android\release\libhelloandroidproject.so</OutputFile>
+    <IncludePath>$(StlIncludeDirectories);$(VS_NdkRoot)\sources\android;$(VS_NdkRoot)\sysroot\usr\include;$(VS_NdkRoot)\sysroot\usr\include\arm-linux-androideabi</IncludePath>
+    <UseMultiToolTask>true</UseMultiToolTask>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <TargetName>libhelloandroidproject</TargetName>
+    <OutDir>$(ProjectDir)output\android\release\</OutDir>
+    <IntDir>temp\vs2017\android\arm64_v8a_noblob_msbuild_vs2017_v3_5_release_lib_android\</IntDir>
+    <TargetExt>.so</TargetExt>
+    <OutputFile>output\android\release\libhelloandroidproject.so</OutputFile>
+    <IncludePath>$(StlIncludeDirectories);$(VS_NdkRoot)\sources\android;$(VS_NdkRoot)\sysroot\usr\include;$(VS_NdkRoot)\sysroot\usr\include\aarch64-linux-android</IncludePath>
+    <UseMultiToolTask>true</UseMultiToolTask>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <TargetName>libhelloandroidproject</TargetName>
+    <OutDir>$(ProjectDir)output\android\release\</OutDir>
+    <IntDir>temp\vs2017\android\x86_64_noblob_msbuild_vs2017_v3_5_release_lib_android\</IntDir>
+    <TargetExt>.so</TargetExt>
+    <OutputFile>output\android\release\libhelloandroidproject.so</OutputFile>
+    <IncludePath>$(StlIncludeDirectories);$(VS_NdkRoot)\sources\android;$(VS_NdkRoot)\sysroot\usr\include;$(VS_NdkRoot)\sysroot\usr\include\x86_64-linux-android</IncludePath>
+    <UseMultiToolTask>true</UseMultiToolTask>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'">
+    <TargetName>libhelloandroidproject</TargetName>
+    <OutDir>$(ProjectDir)output\android\release\</OutDir>
+    <IntDir>temp\vs2017\android\x86_noblob_msbuild_vs2017_v3_5_release_lib_android\</IntDir>
+    <TargetExt>.so</TargetExt>
+    <OutputFile>output\android\release\libhelloandroidproject.so</OutputFile>
+    <IncludePath>$(StlIncludeDirectories);$(VS_NdkRoot)\sources\android;$(VS_NdkRoot)\sysroot\usr\include;$(VS_NdkRoot)\sysroot\usr\include\i686-linux-android</IncludePath>
+    <UseMultiToolTask>true</UseMultiToolTask>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>EnableAllWarnings</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DebugInformationFormat>FullDebug</DebugInformationFormat>
+      <TreatWarningAsError>false</TreatWarningAsError>
+      <OmitFramePointers>false</OmitFramePointers>
+      <UndefineAllPreprocessorDefinitions>false</UndefineAllPreprocessorDefinitions>
+      <ExceptionHandling>Disabled</ExceptionHandling>
+      <BufferSecurityCheck>true</BufferSecurityCheck>
+      <FunctionLevelLinking>false</FunctionLevelLinking>
+      <DataLevelLinking>false</DataLevelLinking>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <AssemblerOutput>NoListing</AssemblerOutput>
+      <CompileAs>Default</CompileAs>
+      <CppLanguageStandard>c++11</CppLanguageStandard>
+    </ClCompile>
+    <Link>
+      <DebuggerSymbolInformation>true</DebuggerSymbolInformation>
+      <OutputFile>output\android\debug\libhelloandroidproject.so</OutputFile>
+      <AdditionalLibraryDirectories>$(StlLibraryPath);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalOptions>-lEGL -lGLESv1_CM</AdditionalOptions>
+      <AdditionalDependencies>;;%(AdditionalDependencies);</AdditionalDependencies>
+      <IgnoreSpecificDefaultLibraries></IgnoreSpecificDefaultLibraries>
+      <GenerateMapFile>output\android\debug\libhelloandroidproject.map</GenerateMapFile>
+      <IncrementalLink>false</IncrementalLink>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>EnableAllWarnings</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DebugInformationFormat>FullDebug</DebugInformationFormat>
+      <TreatWarningAsError>false</TreatWarningAsError>
+      <OmitFramePointers>false</OmitFramePointers>
+      <UndefineAllPreprocessorDefinitions>false</UndefineAllPreprocessorDefinitions>
+      <ExceptionHandling>Disabled</ExceptionHandling>
+      <BufferSecurityCheck>true</BufferSecurityCheck>
+      <FunctionLevelLinking>false</FunctionLevelLinking>
+      <DataLevelLinking>false</DataLevelLinking>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <AssemblerOutput>NoListing</AssemblerOutput>
+      <CompileAs>Default</CompileAs>
+      <CppLanguageStandard>c++11</CppLanguageStandard>
+    </ClCompile>
+    <Link>
+      <DebuggerSymbolInformation>true</DebuggerSymbolInformation>
+      <OutputFile>output\android\debug\libhelloandroidproject.so</OutputFile>
+      <AdditionalLibraryDirectories>$(StlLibraryPath);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalOptions>-lEGL -lGLESv1_CM</AdditionalOptions>
+      <AdditionalDependencies>;;%(AdditionalDependencies);</AdditionalDependencies>
+      <IgnoreSpecificDefaultLibraries></IgnoreSpecificDefaultLibraries>
+      <GenerateMapFile>output\android\debug\libhelloandroidproject.map</GenerateMapFile>
+      <IncrementalLink>false</IncrementalLink>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>EnableAllWarnings</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DebugInformationFormat>FullDebug</DebugInformationFormat>
+      <TreatWarningAsError>false</TreatWarningAsError>
+      <OmitFramePointers>false</OmitFramePointers>
+      <UndefineAllPreprocessorDefinitions>false</UndefineAllPreprocessorDefinitions>
+      <ExceptionHandling>Disabled</ExceptionHandling>
+      <BufferSecurityCheck>true</BufferSecurityCheck>
+      <FunctionLevelLinking>false</FunctionLevelLinking>
+      <DataLevelLinking>false</DataLevelLinking>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <AssemblerOutput>NoListing</AssemblerOutput>
+      <CompileAs>Default</CompileAs>
+      <CppLanguageStandard>c++11</CppLanguageStandard>
+    </ClCompile>
+    <Link>
+      <DebuggerSymbolInformation>true</DebuggerSymbolInformation>
+      <OutputFile>output\android\debug\libhelloandroidproject.so</OutputFile>
+      <AdditionalLibraryDirectories>$(StlLibraryPath);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalOptions>-lEGL -lGLESv1_CM</AdditionalOptions>
+      <AdditionalDependencies>;;%(AdditionalDependencies);</AdditionalDependencies>
+      <IgnoreSpecificDefaultLibraries></IgnoreSpecificDefaultLibraries>
+      <GenerateMapFile>output\android\debug\libhelloandroidproject.map</GenerateMapFile>
+      <IncrementalLink>false</IncrementalLink>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>EnableAllWarnings</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DebugInformationFormat>FullDebug</DebugInformationFormat>
+      <TreatWarningAsError>false</TreatWarningAsError>
+      <OmitFramePointers>false</OmitFramePointers>
+      <UndefineAllPreprocessorDefinitions>false</UndefineAllPreprocessorDefinitions>
+      <ExceptionHandling>Disabled</ExceptionHandling>
+      <BufferSecurityCheck>true</BufferSecurityCheck>
+      <FunctionLevelLinking>false</FunctionLevelLinking>
+      <DataLevelLinking>false</DataLevelLinking>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <AssemblerOutput>NoListing</AssemblerOutput>
+      <CompileAs>Default</CompileAs>
+      <CppLanguageStandard>c++11</CppLanguageStandard>
+    </ClCompile>
+    <Link>
+      <DebuggerSymbolInformation>true</DebuggerSymbolInformation>
+      <OutputFile>output\android\debug\libhelloandroidproject.so</OutputFile>
+      <AdditionalLibraryDirectories>$(StlLibraryPath);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalOptions>-lEGL -lGLESv1_CM</AdditionalOptions>
+      <AdditionalDependencies>;;%(AdditionalDependencies);</AdditionalDependencies>
+      <IgnoreSpecificDefaultLibraries></IgnoreSpecificDefaultLibraries>
+      <GenerateMapFile>output\android\debug\libhelloandroidproject.map</GenerateMapFile>
+      <IncrementalLink>false</IncrementalLink>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>EnableAllWarnings</WarningLevel>
+      <Optimization>Full</Optimization>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DebugInformationFormat>FullDebug</DebugInformationFormat>
+      <TreatWarningAsError>false</TreatWarningAsError>
+      <OmitFramePointers>false</OmitFramePointers>
+      <UndefineAllPreprocessorDefinitions>false</UndefineAllPreprocessorDefinitions>
+      <ExceptionHandling>Disabled</ExceptionHandling>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <DataLevelLinking>true</DataLevelLinking>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <AssemblerOutput>NoListing</AssemblerOutput>
+      <CompileAs>Default</CompileAs>
+      <CppLanguageStandard>c++11</CppLanguageStandard>
+    </ClCompile>
+    <Link>
+      <DebuggerSymbolInformation>true</DebuggerSymbolInformation>
+      <OutputFile>output\android\release\libhelloandroidproject.so</OutputFile>
+      <AdditionalLibraryDirectories>$(StlLibraryPath);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalOptions>-lEGL -lGLESv1_CM</AdditionalOptions>
+      <AdditionalDependencies>;;%(AdditionalDependencies);</AdditionalDependencies>
+      <IgnoreSpecificDefaultLibraries></IgnoreSpecificDefaultLibraries>
+      <GenerateMapFile>output\android\release\libhelloandroidproject.map</GenerateMapFile>
+      <IncrementalLink>false</IncrementalLink>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>EnableAllWarnings</WarningLevel>
+      <Optimization>Full</Optimization>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DebugInformationFormat>FullDebug</DebugInformationFormat>
+      <TreatWarningAsError>false</TreatWarningAsError>
+      <OmitFramePointers>false</OmitFramePointers>
+      <UndefineAllPreprocessorDefinitions>false</UndefineAllPreprocessorDefinitions>
+      <ExceptionHandling>Disabled</ExceptionHandling>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <DataLevelLinking>true</DataLevelLinking>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <AssemblerOutput>NoListing</AssemblerOutput>
+      <CompileAs>Default</CompileAs>
+      <CppLanguageStandard>c++11</CppLanguageStandard>
+    </ClCompile>
+    <Link>
+      <DebuggerSymbolInformation>true</DebuggerSymbolInformation>
+      <OutputFile>output\android\release\libhelloandroidproject.so</OutputFile>
+      <AdditionalLibraryDirectories>$(StlLibraryPath);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalOptions>-lEGL -lGLESv1_CM</AdditionalOptions>
+      <AdditionalDependencies>;;%(AdditionalDependencies);</AdditionalDependencies>
+      <IgnoreSpecificDefaultLibraries></IgnoreSpecificDefaultLibraries>
+      <GenerateMapFile>output\android\release\libhelloandroidproject.map</GenerateMapFile>
+      <IncrementalLink>false</IncrementalLink>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>EnableAllWarnings</WarningLevel>
+      <Optimization>Full</Optimization>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DebugInformationFormat>FullDebug</DebugInformationFormat>
+      <TreatWarningAsError>false</TreatWarningAsError>
+      <OmitFramePointers>false</OmitFramePointers>
+      <UndefineAllPreprocessorDefinitions>false</UndefineAllPreprocessorDefinitions>
+      <ExceptionHandling>Disabled</ExceptionHandling>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <DataLevelLinking>true</DataLevelLinking>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <AssemblerOutput>NoListing</AssemblerOutput>
+      <CompileAs>Default</CompileAs>
+      <CppLanguageStandard>c++11</CppLanguageStandard>
+    </ClCompile>
+    <Link>
+      <DebuggerSymbolInformation>true</DebuggerSymbolInformation>
+      <OutputFile>output\android\release\libhelloandroidproject.so</OutputFile>
+      <AdditionalLibraryDirectories>$(StlLibraryPath);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalOptions>-lEGL -lGLESv1_CM</AdditionalOptions>
+      <AdditionalDependencies>;;%(AdditionalDependencies);</AdditionalDependencies>
+      <IgnoreSpecificDefaultLibraries></IgnoreSpecificDefaultLibraries>
+      <GenerateMapFile>output\android\release\libhelloandroidproject.map</GenerateMapFile>
+      <IncrementalLink>false</IncrementalLink>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>EnableAllWarnings</WarningLevel>
+      <Optimization>Full</Optimization>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DebugInformationFormat>FullDebug</DebugInformationFormat>
+      <TreatWarningAsError>false</TreatWarningAsError>
+      <OmitFramePointers>false</OmitFramePointers>
+      <UndefineAllPreprocessorDefinitions>false</UndefineAllPreprocessorDefinitions>
+      <ExceptionHandling>Disabled</ExceptionHandling>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <DataLevelLinking>true</DataLevelLinking>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <AssemblerOutput>NoListing</AssemblerOutput>
+      <CompileAs>Default</CompileAs>
+      <CppLanguageStandard>c++11</CppLanguageStandard>
+    </ClCompile>
+    <Link>
+      <DebuggerSymbolInformation>true</DebuggerSymbolInformation>
+      <OutputFile>output\android\release\libhelloandroidproject.so</OutputFile>
+      <AdditionalLibraryDirectories>$(StlLibraryPath);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalOptions>-lEGL -lGLESv1_CM</AdditionalOptions>
+      <AdditionalDependencies>;;%(AdditionalDependencies);</AdditionalDependencies>
+      <IgnoreSpecificDefaultLibraries></IgnoreSpecificDefaultLibraries>
+      <GenerateMapFile>output\android\release\libhelloandroidproject.map</GenerateMapFile>
+      <IncrementalLink>false</IncrementalLink>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\codebase\android_native_app_glue.h" />
+    <ClInclude Include="..\codebase\Cube.h" />
+    <ClInclude Include="..\codebase\pch.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\codebase\android_native_app_glue.c" />
+    <ClCompile Include="..\codebase\Cube.cpp" />
+    <ClCompile Include="..\codebase\main.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/samples/HelloAndroid/reference/projects/helloandroidproject.vs2017.vcxproj.filters
+++ b/samples/HelloAndroid/reference/projects/helloandroidproject.vs2017.vcxproj.filters
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="..\codebase\android_native_app_glue.c" />
+    <ClCompile Include="..\codebase\Cube.cpp" />
+    <ClCompile Include="..\codebase\main.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\codebase\android_native_app_glue.h" />
+    <ClInclude Include="..\codebase\Cube.h" />
+    <ClInclude Include="..\codebase\pch.h" />
+  </ItemGroup>
+</Project>

--- a/samples/Sharpmake.Samples.sharpmake.cs
+++ b/samples/Sharpmake.Samples.sharpmake.cs
@@ -16,6 +16,7 @@ namespace SharpmakeGen.Samples
             SourceRootPath = @"[project.SharpmakeCsPath]\[project.Name]";
             SourceFilesExcludeRegex.Add(
                 @"\\codebase\\",
+                @"\\package\\",
                 @"\\projects\\",
                 @"\\reference\\"
             );
@@ -155,6 +156,15 @@ namespace SharpmakeGen.Samples
         public FastBuildSimpleExecutable()
         {
             Name = "FastBuildSimpleExecutable";
+        }
+    }
+
+    [Generate]
+    public class HelloAndroidProject : SampleProject
+    {
+        public HelloAndroidProject()
+        {
+            Name = "HelloAndroid";
         }
     }
 


### PR DESCRIPTION
I extracted the changes from the old PR that are still relevant, adapted them to the custom targets pattern and broke them down into more focused commits.

Not the samples won't build without first accepting #99 

I also noticed that the HelloXcode sample isn't being built by default in UpdateSamplesOutput. Is that because it has a ton of absolute paths in it's reference files?