### PR TITLE
[Custom Build Steps] Fixes to get custom build steps working.

### DIFF
--- a/Sharpmake.Generators/VisualStudio/Vcxproj.cs
+++ b/Sharpmake.Generators/VisualStudio/Vcxproj.cs
@@ -181,7 +181,7 @@ namespace Sharpmake.Generators.VisualStudio
                 relativeBuildStep.AdditionalInputs.Add(relativeBuildStep.Executable);
                 // Build the command.
                 string command = string.Format(
-                    "{0} {1}",
+                    @"""{0}"" {1}",
                     relativeBuildStep.Executable,
                     relativeBuildStep.ExecutableArguments
                 );
@@ -1398,10 +1398,12 @@ namespace Sharpmake.Generators.VisualStudio
                     {
                         fileGenerator.Write(Template.Project.ProjectFilesCustomBuildBegin);
 
+                        var fileNameProjectRelative = Util.PathMakeStandard(file.FileNameProjectRelative);
+
                         foreach (Project.Configuration conf in context.ProjectConfigurations)
                         {
                             CombinedCustomFileBuildStep buildStep;
-                            if (configurationCustomFileBuildSteps[conf].TryGetValue(file.FileNameProjectRelative, out buildStep))
+                            if (configurationCustomFileBuildSteps[conf].TryGetValue(fileNameProjectRelative, out buildStep))
                             {
                                 using (fileGenerator.Declare("conf", conf))
                                 using (fileGenerator.Declare("platformName", Util.GetPlatformString(conf.Platform, conf.Project, conf.Target)))

--- a/samples/QTFileCustomBuild/reference/projects/qtfilecustombuild_vs2017_win64.vcxproj
+++ b/samples/QTFileCustomBuild/reference/projects/qtfilecustombuild_vs2017_win64.vcxproj
@@ -345,89 +345,89 @@
   <ItemGroup>
     <CustomBuild Include="..\codebase\exec.qrc">
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Rcc Debug exec.qrc</Message>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">..\qt\5.9.2\msvc2017_64\bin\rcc.exe -name exec ..\codebase\exec.qrc -o obj\win64\qt\debug\qrc_exec.cpp&#x0D;&#x0A;</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">"..\qt\5.9.2\msvc2017_64\bin\rcc.exe" -name exec ..\codebase\exec.qrc -o obj\win64\qt\debug\qrc_exec.cpp&#x0D;&#x0A;</Command>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">..\qt\5.9.2\msvc2017_64\bin\rcc.exe</AdditionalInputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">obj\win64\qt\debug\qrc_exec.cpp</Outputs>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Rcc Release exec.qrc</Message>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">..\qt\5.9.2\msvc2017_64\bin\rcc.exe -name exec ..\codebase\exec.qrc -o obj\win64\qt\release\qrc_exec.cpp&#x0D;&#x0A;</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"..\qt\5.9.2\msvc2017_64\bin\rcc.exe" -name exec ..\codebase\exec.qrc -o obj\win64\qt\release\qrc_exec.cpp&#x0D;&#x0A;</Command>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">..\qt\5.9.2\msvc2017_64\bin\rcc.exe</AdditionalInputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">obj\win64\qt\release\qrc_exec.cpp</Outputs>
       <Message Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">Rcc Retail exec.qrc</Message>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">..\qt\5.9.2\msvc2017_64\bin\rcc.exe -name exec ..\codebase\exec.qrc -o obj\win64\qt\retail\qrc_exec.cpp&#x0D;&#x0A;</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">"..\qt\5.9.2\msvc2017_64\bin\rcc.exe" -name exec ..\codebase\exec.qrc -o obj\win64\qt\retail\qrc_exec.cpp&#x0D;&#x0A;</Command>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">..\qt\5.9.2\msvc2017_64\bin\rcc.exe</AdditionalInputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">obj\win64\qt\retail\qrc_exec.cpp</Outputs>
     </CustomBuild>
     <CustomBuild Include="..\codebase\floatanglespinbox.h">
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Moc Debug floatanglespinbox.h</Message>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">..\qt\5.9.2\msvc2017_64\bin\moc.exe -D_MSC_VER=1910 -DQT_SHARED -DWIN32 -I. -I..\qt\5.9.2\msvc2017_64\include -Iobj\win64\qt\debug  -fstdafx.h -f..\codebase\floatanglespinbox.h ..\codebase\floatanglespinbox.h -o obj\win64\qt\debug\moc_floatanglespinbox.cpp&#x0D;&#x0A;</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">"..\qt\5.9.2\msvc2017_64\bin\moc.exe" -D_MSC_VER=1910 -DQT_SHARED -DWIN32 -I. -I..\qt\5.9.2\msvc2017_64\include -Iobj\win64\qt\debug  -fstdafx.h -f..\codebase\floatanglespinbox.h ..\codebase\floatanglespinbox.h -o obj\win64\qt\debug\moc_floatanglespinbox.cpp&#x0D;&#x0A;</Command>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">..\qt\5.9.2\msvc2017_64\bin\moc.exe</AdditionalInputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">obj\win64\qt\debug\moc_floatanglespinbox.cpp</Outputs>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Moc Release floatanglespinbox.h</Message>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">..\qt\5.9.2\msvc2017_64\bin\moc.exe -D_MSC_VER=1910 -DQT_NO_DEBUG -DQT_SHARED -DWIN32 -I. -I..\qt\5.9.2\msvc2017_64\include -Iobj\win64\qt\release  -fstdafx.h -f..\codebase\floatanglespinbox.h ..\codebase\floatanglespinbox.h -o obj\win64\qt\release\moc_floatanglespinbox.cpp&#x0D;&#x0A;</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"..\qt\5.9.2\msvc2017_64\bin\moc.exe" -D_MSC_VER=1910 -DQT_NO_DEBUG -DQT_SHARED -DWIN32 -I. -I..\qt\5.9.2\msvc2017_64\include -Iobj\win64\qt\release  -fstdafx.h -f..\codebase\floatanglespinbox.h ..\codebase\floatanglespinbox.h -o obj\win64\qt\release\moc_floatanglespinbox.cpp&#x0D;&#x0A;</Command>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">..\qt\5.9.2\msvc2017_64\bin\moc.exe</AdditionalInputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">obj\win64\qt\release\moc_floatanglespinbox.cpp</Outputs>
       <Message Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">Moc Retail floatanglespinbox.h</Message>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">..\qt\5.9.2\msvc2017_64\bin\moc.exe -D_MSC_VER=1910 -DQT_NO_DEBUG -DQT_SHARED -DWIN32 -I. -I..\qt\5.9.2\msvc2017_64\include -Iobj\win64\qt\retail  -fstdafx.h -f..\codebase\floatanglespinbox.h ..\codebase\floatanglespinbox.h -o obj\win64\qt\retail\moc_floatanglespinbox.cpp&#x0D;&#x0A;</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">"..\qt\5.9.2\msvc2017_64\bin\moc.exe" -D_MSC_VER=1910 -DQT_NO_DEBUG -DQT_SHARED -DWIN32 -I. -I..\qt\5.9.2\msvc2017_64\include -Iobj\win64\qt\retail  -fstdafx.h -f..\codebase\floatanglespinbox.h ..\codebase\floatanglespinbox.h -o obj\win64\qt\retail\moc_floatanglespinbox.cpp&#x0D;&#x0A;</Command>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">..\qt\5.9.2\msvc2017_64\bin\moc.exe</AdditionalInputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">obj\win64\qt\retail\moc_floatanglespinbox.cpp</Outputs>
     </CustomBuild>
     <CustomBuild Include="..\codebase\floatcosanglespinbox.h">
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Moc Debug floatcosanglespinbox.h</Message>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">..\qt\5.9.2\msvc2017_64\bin\moc.exe -D_MSC_VER=1910 -DQT_SHARED -DWIN32 -I. -I..\qt\5.9.2\msvc2017_64\include -Iobj\win64\qt\debug  -fstdafx.h -f..\codebase\floatcosanglespinbox.h ..\codebase\floatcosanglespinbox.h -o obj\win64\qt\debug\moc_floatcosanglespinbox.cpp&#x0D;&#x0A;</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">"..\qt\5.9.2\msvc2017_64\bin\moc.exe" -D_MSC_VER=1910 -DQT_SHARED -DWIN32 -I. -I..\qt\5.9.2\msvc2017_64\include -Iobj\win64\qt\debug  -fstdafx.h -f..\codebase\floatcosanglespinbox.h ..\codebase\floatcosanglespinbox.h -o obj\win64\qt\debug\moc_floatcosanglespinbox.cpp&#x0D;&#x0A;</Command>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">..\qt\5.9.2\msvc2017_64\bin\moc.exe</AdditionalInputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">obj\win64\qt\debug\moc_floatcosanglespinbox.cpp</Outputs>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Moc Release floatcosanglespinbox.h</Message>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">..\qt\5.9.2\msvc2017_64\bin\moc.exe -D_MSC_VER=1910 -DQT_NO_DEBUG -DQT_SHARED -DWIN32 -I. -I..\qt\5.9.2\msvc2017_64\include -Iobj\win64\qt\release  -fstdafx.h -f..\codebase\floatcosanglespinbox.h ..\codebase\floatcosanglespinbox.h -o obj\win64\qt\release\moc_floatcosanglespinbox.cpp&#x0D;&#x0A;</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"..\qt\5.9.2\msvc2017_64\bin\moc.exe" -D_MSC_VER=1910 -DQT_NO_DEBUG -DQT_SHARED -DWIN32 -I. -I..\qt\5.9.2\msvc2017_64\include -Iobj\win64\qt\release  -fstdafx.h -f..\codebase\floatcosanglespinbox.h ..\codebase\floatcosanglespinbox.h -o obj\win64\qt\release\moc_floatcosanglespinbox.cpp&#x0D;&#x0A;</Command>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">..\qt\5.9.2\msvc2017_64\bin\moc.exe</AdditionalInputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">obj\win64\qt\release\moc_floatcosanglespinbox.cpp</Outputs>
       <Message Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">Moc Retail floatcosanglespinbox.h</Message>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">..\qt\5.9.2\msvc2017_64\bin\moc.exe -D_MSC_VER=1910 -DQT_NO_DEBUG -DQT_SHARED -DWIN32 -I. -I..\qt\5.9.2\msvc2017_64\include -Iobj\win64\qt\retail  -fstdafx.h -f..\codebase\floatcosanglespinbox.h ..\codebase\floatcosanglespinbox.h -o obj\win64\qt\retail\moc_floatcosanglespinbox.cpp&#x0D;&#x0A;</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">"..\qt\5.9.2\msvc2017_64\bin\moc.exe" -D_MSC_VER=1910 -DQT_NO_DEBUG -DQT_SHARED -DWIN32 -I. -I..\qt\5.9.2\msvc2017_64\include -Iobj\win64\qt\retail  -fstdafx.h -f..\codebase\floatcosanglespinbox.h ..\codebase\floatcosanglespinbox.h -o obj\win64\qt\retail\moc_floatcosanglespinbox.cpp&#x0D;&#x0A;</Command>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">..\qt\5.9.2\msvc2017_64\bin\moc.exe</AdditionalInputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">obj\win64\qt\retail\moc_floatcosanglespinbox.cpp</Outputs>
     </CustomBuild>
     <CustomBuild Include="..\codebase\privatewidget.h">
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Moc Debug privatewidget.h</Message>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">..\qt\5.9.2\msvc2017_64\bin\moc.exe -D_MSC_VER=1910 -DQT_SHARED -DWIN32 -I. -I..\qt\5.9.2\msvc2017_64\include -Iobj\win64\qt\debug  -fstdafx.h -f..\codebase\privatewidget.h ..\codebase\privatewidget.h -o obj\win64\qt\debug\moc_privatewidget.cpp&#x0D;&#x0A;</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">"..\qt\5.9.2\msvc2017_64\bin\moc.exe" -D_MSC_VER=1910 -DQT_SHARED -DWIN32 -I. -I..\qt\5.9.2\msvc2017_64\include -Iobj\win64\qt\debug  -fstdafx.h -f..\codebase\privatewidget.h ..\codebase\privatewidget.h -o obj\win64\qt\debug\moc_privatewidget.cpp&#x0D;&#x0A;</Command>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">..\qt\5.9.2\msvc2017_64\bin\moc.exe</AdditionalInputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">obj\win64\qt\debug\moc_privatewidget.cpp</Outputs>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Moc Release privatewidget.h</Message>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">..\qt\5.9.2\msvc2017_64\bin\moc.exe -D_MSC_VER=1910 -DQT_NO_DEBUG -DQT_SHARED -DWIN32 -I. -I..\qt\5.9.2\msvc2017_64\include -Iobj\win64\qt\release  -fstdafx.h -f..\codebase\privatewidget.h ..\codebase\privatewidget.h -o obj\win64\qt\release\moc_privatewidget.cpp&#x0D;&#x0A;</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"..\qt\5.9.2\msvc2017_64\bin\moc.exe" -D_MSC_VER=1910 -DQT_NO_DEBUG -DQT_SHARED -DWIN32 -I. -I..\qt\5.9.2\msvc2017_64\include -Iobj\win64\qt\release  -fstdafx.h -f..\codebase\privatewidget.h ..\codebase\privatewidget.h -o obj\win64\qt\release\moc_privatewidget.cpp&#x0D;&#x0A;</Command>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">..\qt\5.9.2\msvc2017_64\bin\moc.exe</AdditionalInputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">obj\win64\qt\release\moc_privatewidget.cpp</Outputs>
       <Message Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">Moc Retail privatewidget.h</Message>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">..\qt\5.9.2\msvc2017_64\bin\moc.exe -D_MSC_VER=1910 -DQT_NO_DEBUG -DQT_SHARED -DWIN32 -I. -I..\qt\5.9.2\msvc2017_64\include -Iobj\win64\qt\retail  -fstdafx.h -f..\codebase\privatewidget.h ..\codebase\privatewidget.h -o obj\win64\qt\retail\moc_privatewidget.cpp&#x0D;&#x0A;</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">"..\qt\5.9.2\msvc2017_64\bin\moc.exe" -D_MSC_VER=1910 -DQT_NO_DEBUG -DQT_SHARED -DWIN32 -I. -I..\qt\5.9.2\msvc2017_64\include -Iobj\win64\qt\retail  -fstdafx.h -f..\codebase\privatewidget.h ..\codebase\privatewidget.h -o obj\win64\qt\retail\moc_privatewidget.cpp&#x0D;&#x0A;</Command>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">..\qt\5.9.2\msvc2017_64\bin\moc.exe</AdditionalInputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">obj\win64\qt\retail\moc_privatewidget.cpp</Outputs>
     </CustomBuild>
     <CustomBuild Include="..\codebase\privatewidget.ui">
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Uic Debug privatewidget.ui</Message>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">..\qt\5.9.2\msvc2017_64\bin\uic.exe ..\codebase\privatewidget.ui -o obj\win64\qt\debug\ui_privatewidget.h&#x0D;&#x0A;</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">"..\qt\5.9.2\msvc2017_64\bin\uic.exe" ..\codebase\privatewidget.ui -o obj\win64\qt\debug\ui_privatewidget.h&#x0D;&#x0A;</Command>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">..\qt\5.9.2\msvc2017_64\bin\uic.exe</AdditionalInputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">obj\win64\qt\debug\ui_privatewidget.h</Outputs>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Uic Release privatewidget.ui</Message>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">..\qt\5.9.2\msvc2017_64\bin\uic.exe ..\codebase\privatewidget.ui -o obj\win64\qt\release\ui_privatewidget.h&#x0D;&#x0A;</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"..\qt\5.9.2\msvc2017_64\bin\uic.exe" ..\codebase\privatewidget.ui -o obj\win64\qt\release\ui_privatewidget.h&#x0D;&#x0A;</Command>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">..\qt\5.9.2\msvc2017_64\bin\uic.exe</AdditionalInputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">obj\win64\qt\release\ui_privatewidget.h</Outputs>
       <Message Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">Uic Retail privatewidget.ui</Message>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">..\qt\5.9.2\msvc2017_64\bin\uic.exe ..\codebase\privatewidget.ui -o obj\win64\qt\retail\ui_privatewidget.h&#x0D;&#x0A;</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">"..\qt\5.9.2\msvc2017_64\bin\uic.exe" ..\codebase\privatewidget.ui -o obj\win64\qt\retail\ui_privatewidget.h&#x0D;&#x0A;</Command>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">..\qt\5.9.2\msvc2017_64\bin\uic.exe</AdditionalInputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">obj\win64\qt\retail\ui_privatewidget.h</Outputs>
     </CustomBuild>
     <CustomBuild Include="obj\win64\qt\debug\privatewidget.inl">
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Moc Debug privatewidget.cpp</Message>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">..\qt\5.9.2\msvc2017_64\bin\moc.exe -D_MSC_VER=1910 -DQT_SHARED -DWIN32 -I. -I..\qt\5.9.2\msvc2017_64\include -Iobj\win64\qt\debug  ..\codebase\privatewidget.cpp -o obj\win64\qt\debug\privatewidget.moc&#x0D;&#x0A;</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">"..\qt\5.9.2\msvc2017_64\bin\moc.exe" -D_MSC_VER=1910 -DQT_SHARED -DWIN32 -I. -I..\qt\5.9.2\msvc2017_64\include -Iobj\win64\qt\debug  ..\codebase\privatewidget.cpp -o obj\win64\qt\debug\privatewidget.moc&#x0D;&#x0A;</Command>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">..\codebase\privatewidget.cpp;..\qt\5.9.2\msvc2017_64\bin\moc.exe</AdditionalInputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">obj\win64\qt\debug\privatewidget.moc</Outputs>
     </CustomBuild>
     <CustomBuild Include="obj\win64\qt\release\privatewidget.inl">
       <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Moc Release privatewidget.cpp</Message>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">..\qt\5.9.2\msvc2017_64\bin\moc.exe -D_MSC_VER=1910 -DQT_NO_DEBUG -DQT_SHARED -DWIN32 -I. -I..\qt\5.9.2\msvc2017_64\include -Iobj\win64\qt\release  ..\codebase\privatewidget.cpp -o obj\win64\qt\release\privatewidget.moc&#x0D;&#x0A;</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"..\qt\5.9.2\msvc2017_64\bin\moc.exe" -D_MSC_VER=1910 -DQT_NO_DEBUG -DQT_SHARED -DWIN32 -I. -I..\qt\5.9.2\msvc2017_64\include -Iobj\win64\qt\release  ..\codebase\privatewidget.cpp -o obj\win64\qt\release\privatewidget.moc&#x0D;&#x0A;</Command>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">..\codebase\privatewidget.cpp;..\qt\5.9.2\msvc2017_64\bin\moc.exe</AdditionalInputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">obj\win64\qt\release\privatewidget.moc</Outputs>
     </CustomBuild>
     <CustomBuild Include="obj\win64\qt\retail\privatewidget.inl">
       <Message Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">Moc Retail privatewidget.cpp</Message>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">..\qt\5.9.2\msvc2017_64\bin\moc.exe -D_MSC_VER=1910 -DQT_NO_DEBUG -DQT_SHARED -DWIN32 -I. -I..\qt\5.9.2\msvc2017_64\include -Iobj\win64\qt\retail  ..\codebase\privatewidget.cpp -o obj\win64\qt\retail\privatewidget.moc&#x0D;&#x0A;</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">"..\qt\5.9.2\msvc2017_64\bin\moc.exe" -D_MSC_VER=1910 -DQT_NO_DEBUG -DQT_SHARED -DWIN32 -I. -I..\qt\5.9.2\msvc2017_64\include -Iobj\win64\qt\retail  ..\codebase\privatewidget.cpp -o obj\win64\qt\retail\privatewidget.moc&#x0D;&#x0A;</Command>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">..\codebase\privatewidget.cpp;..\qt\5.9.2\msvc2017_64\bin\moc.exe</AdditionalInputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Retail|x64'">obj\win64\qt\retail\privatewidget.moc</Outputs>
     </CustomBuild>


### PR DESCRIPTION
* Add quotes to executable to support spaces in paths since the quotes can't be added by the user.
* Standardize the path when looking up the build step since it may be lower cased.