### PR TITLE
[Samples] Fix launch arguments to work with new sharpmake output location

### DIFF
--- a/samples/Sharpmake.Samples.sharpmake.cs
+++ b/samples/Sharpmake.Samples.sharpmake.cs
@@ -35,8 +35,8 @@ namespace SharpmakeGen.Samples
             conf.CsprojUserFile = new Project.Configuration.CsprojUserFileSettings
             {
                 StartAction = Project.Configuration.CsprojUserFileSettings.StartActionSetting.Program,
-                StartProgram = @"[conf.TargetPath]\Sharpmake.Application.exe",
-                StartArguments = "/sources(\"[project.SharpmakeMainFile]\")",
+                StartProgram = @"[project.RootPath]\tmp\bin\[conf.Target.Optimization]\sharpmake.application\Sharpmake.Application.exe",
+                StartArguments = "/sources('[project.SharpmakeMainFile]')",
                 WorkingDirectory = "[project.SourceRootPath]",
                 OverwriteExistingFile = false
             };


### PR DESCRIPTION
With this you can hit f5 on a sample library again.
