### PR TITLE
.ExecAlways flag added to BuildStepExecutable step (Exec)

### DIFF
--- a/Sharpmake.Generators/FastBuild/Bff.Template.cs
+++ b/Sharpmake.Generators/FastBuild/Bff.Template.cs
@@ -520,6 +520,7 @@ Exec( '[fastBuildPreBuildName]' )
   .ExecUseStdOutAsOutput = [fastBuildPrebuildUseStdOutAsOutput]
   .ExecAlwaysShowOutput =  [fastBuildPrebuildAlwaysShowOutput]
   .PreBuildDependencies = [fastBuildExecPreBuildDependencies]
+  .ExecAlways           = [fastBuildExecAlways]
 }
 
 ";

--- a/Sharpmake.Generators/FastBuild/Bff.Util.cs
+++ b/Sharpmake.Generators/FastBuild/Bff.Util.cs
@@ -123,6 +123,7 @@ namespace Sharpmake.Generators.FastBuild
             public string WorkingPath;
             public bool UseStdOutAsOutput;
             public bool AlwaysShowOutput;
+            public bool ExecAlways;
 
             public ExecNode(string buildStepKey, Project.Configuration.BuildStepExecutable buildStep)
             {
@@ -137,6 +138,7 @@ namespace Sharpmake.Generators.FastBuild
                 WorkingPath = buildStep.ExecutableWorkingDirectory;
                 UseStdOutAsOutput = buildStep.FastBuildUseStdOutAsOutput;
                 AlwaysShowOutput = buildStep.FastBuildAlwaysShowOutput;
+                ExecAlways = buildStep.FastBuildExecAlways;
             }
 
             public override string Resolve(string rootPath, string bffFilePath, Resolver resolver)
@@ -152,6 +154,7 @@ namespace Sharpmake.Generators.FastBuild
                 using (resolver.NewScopedParameter("fastBuildPrebuildUseStdOutAsOutput", UseStdOutAsOutput ? "true" : FileGeneratorUtilities.RemoveLineTag))
                 using (resolver.NewScopedParameter("fastBuildPrebuildAlwaysShowOutput", AlwaysShowOutput ? "true" : FileGeneratorUtilities.RemoveLineTag))
                 using (resolver.NewScopedParameter("fastBuildExecPreBuildDependencies", Dependencies.Count > 0 ? UtilityMethods.FBuildFormatList(Dependencies.ToList(), 26) : FileGeneratorUtilities.RemoveLineTag))
+                using (resolver.NewScopedParameter("fastBuildExecAlways", ExecAlways ? "true" : FileGeneratorUtilities.RemoveLineTag))
                 {
                     return resolver.Resolve(Bff.Template.ConfigurationFile.GenericExecutableSection);
                 }

--- a/Sharpmake/Project.Configuration.cs
+++ b/Sharpmake/Project.Configuration.cs
@@ -1335,7 +1335,8 @@ namespace Sharpmake
                     string executableWorkingDirectory = "",
                     bool isNameSpecific = false,
                     bool useStdOutAsOutput = false,
-                    bool alwaysShowOutput = false)
+                    bool alwaysShowOutput = false,
+                    bool executeAlways = false)
 
                 {
                     ExecutableFile = executableFile;
@@ -1346,6 +1347,7 @@ namespace Sharpmake
                     IsNameSpecific = isNameSpecific;
                     FastBuildUseStdOutAsOutput = useStdOutAsOutput;
                     FastBuildAlwaysShowOutput = alwaysShowOutput;
+                    FastBuildExecAlways = executeAlways;
                 }
 
                 /// <summary>
@@ -1384,6 +1386,11 @@ namespace Sharpmake
                 public bool FastBuildUseStdOutAsOutput = false;
 
                 public bool FastBuildAlwaysShowOutput = false;
+
+                /// <summary>
+                /// Gets or sets whether the step should be executed every time.
+                /// </summary>
+                public bool FastBuildExecAlways = false;
 
                 internal override void Resolve(Resolver resolver)
                 {


### PR DESCRIPTION
FastBuild's **Exec** step has ._ExecAlways_ parameter that was not exposed to the developers that use SharpMake. 

Its valuable for code generation tasks that should be run every time.

More details here:
https://www.fastbuild.org/docs/functions/exec.html