### PR TITLE
Add option to control inheriting pre-build steps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,4 +66,3 @@ Sharpmake.VC.db
 
 # Desktop Services Store on MacOS
 **/.DS_Store
-deploy

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ Sharpmake.VC.db
 
 # Desktop Services Store on MacOS
 **/.DS_Store
+deploy

--- a/Sharpmake.Generators/VisualStudio/ProjectOptionsGenerator.cs
+++ b/Sharpmake.Generators/VisualStudio/ProjectOptionsGenerator.cs
@@ -1824,7 +1824,9 @@ namespace Sharpmake.Generators.VisualStudio
 
             if (!context.Configuration.IsFastBuild)
             {
-                if (context.Configuration.Output == Project.Configuration.OutputType.Exe || context.Configuration.ExecuteTargetCopy)
+                if (   context.Configuration.Output == Project.Configuration.OutputType.Exe 
+                    || context.Configuration.Output == Project.Configuration.OutputType.Lib 
+                    || context.Configuration.ExecuteTargetCopy)
                 {
                     foreach (var customEvent in context.Configuration.ResolvedEventPreBuildExe)
                     {

--- a/samples/PreBuildStepDependency/PreBuildStepDependency.sharpmake.cs
+++ b/samples/PreBuildStepDependency/PreBuildStepDependency.sharpmake.cs
@@ -1,0 +1,142 @@
+﻿// Copyright (c) 2017 Ubisoft Entertainment
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Sharpmake;
+
+namespace PreBuildStepDependency
+{
+    [Generate]
+    public class ToolProject : Project
+    {
+        public ToolProject()
+        {
+            Name = "Tool";
+
+            AddTargets(new Target(
+                    Platform.win64,
+                    DevEnv.vs2019,
+                    Optimization.Debug // | Optimization.Release
+            ));
+
+            SourceRootPath = @"[project.SharpmakeCsPath]\codebase\tool";
+        }
+
+        [Configure()]
+        public void ConfigureAll(Configuration conf, Target target)
+        {
+            conf.ProjectFileName = "[project.Name]_[target.DevEnv]_[target.Platform]";
+            conf.ProjectPath = @"[project.SharpmakeCsPath]\projects";
+            conf.IntermediatePath = @"[project.SharpmakeCsPath]\projects\intermediate\[project.Name]_[target.DevEnv]_[target.Platform]";
+            conf.Output = Configuration.OutputType.Exe;
+        }
+    }
+
+    [Generate]
+    public class AppProject : Project
+    {
+        public AppProject()
+        {
+            Name = "App";
+
+
+            AddTargets(new Target(
+                    Platform.win64,
+                    DevEnv.vs2019,
+                    Optimization.Debug // | Optimization.Release
+            ));
+
+            SourceRootPath = @"[project.SharpmakeCsPath]\codebase\app";
+        }
+
+        [Configure()]
+        public void ConfigureAll(Configuration conf, Target target)
+        {
+            conf.ProjectFileName = "[project.Name]_[target.DevEnv]_[target.Platform]";
+            conf.ProjectPath = @"[project.SharpmakeCsPath]\projects";
+            conf.IntermediatePath = @"[project.SharpmakeCsPath]\projects\intermediate\[project.Name]_[target.DevEnv]_[target.Platform]";
+
+            conf.AddPrivateDependency<LibProject>(target, DependencySetting.DefaultWithoutBuildSteps);
+
+            Configuration.BuildStepExecutable tool = new Configuration.BuildStepExecutable(@"[project.SharpmakeCsPath]\projects\output\win64\debug\tool.exe", "", "", "-Flag1 -Flag2 -DoStuff=256");
+            conf.EventPreBuildExe.Add(tool);
+
+        }
+    }
+
+    [Generate]
+    public class LibProject : Project
+    {
+        public LibProject()
+        {
+            Name = "Lib";
+
+            AddTargets(new Target(
+                    Platform.win64,
+                    DevEnv.vs2019,
+                    Optimization.Debug // | Optimization.Release
+            ));
+
+            SourceRootPath = @"[project.SharpmakeCsPath]\codebase\lib";
+        }
+
+        [Configure()]
+        public void ConfigureAll(Configuration conf, Target target)
+        {
+            conf.ProjectFileName = "[project.Name]_[target.DevEnv]_[target.Platform]";
+            conf.ProjectPath = @"[project.SharpmakeCsPath]\projects";
+            conf.IntermediatePath = @"[project.SharpmakeCsPath]\projects\intermediate\[project.Name]_[target.DevEnv]_[target.Platform]";
+
+            conf.Output = Configuration.OutputType.Lib;
+            conf.IncludePaths.Add(conf.Project.SourceRootPath);
+
+            // Depend on our 'tool' to be build first 
+            conf.AddPrivateDependency<ToolProject>(target, DependencySetting.OnlyBuildOrder);
+
+            Configuration.BuildStepExecutable tool = new Configuration.BuildStepExecutable(@"[project.SharpmakeCsPath]\projects\output\win64\debug\tool.exe", "", "", "-Flag1 -Flag2 -DoStuff=123");
+            conf.EventPreBuildExe.Add(tool);
+        }
+    }
+
+
+    [Sharpmake.Generate]
+    public class PreBuildStepDependencySolution : Sharpmake.Solution
+    {
+        public PreBuildStepDependencySolution()
+        {
+            Name = "PreBuildStepDependency";
+
+            AddTargets(new Target(
+                    Platform.win64,
+                    DevEnv.vs2019,
+                    Optimization.Debug // | Optimization.Release
+            ));
+        }
+
+        [Configure()]
+        public void ConfigureAll(Configuration conf, Target target)
+        {
+            conf.SolutionFileName = "[solution.Name]_[target.DevEnv]_[target.Platform]";
+            conf.SolutionPath = @"[solution.SharpmakeCsPath]\projects";
+            conf.AddProject<LibProject>(target);
+            conf.AddProject<AppProject>(target);
+            conf.AddProject<ToolProject>(target);
+        }
+
+        [Sharpmake.Main]
+        public static void SharpmakeMain(Sharpmake.Arguments arguments)
+        {
+            arguments.Generate<PreBuildStepDependencySolution>();
+        }
+    }
+}

--- a/samples/PreBuildStepDependency/codebase/app/main.cpp
+++ b/samples/PreBuildStepDependency/codebase/app/main.cpp
@@ -1,0 +1,12 @@
+#include <stdio.h>
+
+#include "lib.h"
+
+int main(const int, char*)
+{
+    printf("[APP]: Executing app");
+
+    execute_my_fn();
+
+    return 0;
+}

--- a/samples/PreBuildStepDependency/codebase/lib/lib.cpp
+++ b/samples/PreBuildStepDependency/codebase/lib/lib.cpp
@@ -1,0 +1,5 @@
+#include <stdio.h>
+
+void execute_my_fn() {
+    printf("\"execute_my_fn\" has been called.");
+}

--- a/samples/PreBuildStepDependency/codebase/lib/lib.h
+++ b/samples/PreBuildStepDependency/codebase/lib/lib.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void execute_my_fn();

--- a/samples/PreBuildStepDependency/codebase/tool/main.cpp
+++ b/samples/PreBuildStepDependency/codebase/tool/main.cpp
@@ -1,0 +1,12 @@
+#include <stdio.h>
+int main(const int argc, char* argvs[])
+{
+    printf("[PREBUILD]: Calling prebuilt tool.\n");
+    printf("[PREBUILD]: ");
+    for (int i = 0; i < argc; ++i)
+    {
+        printf("%s ", argvs[i]);
+    }
+    printf("\n");
+    return 0;
+}

--- a/samples/Sharpmake.Samples.sharpmake.cs
+++ b/samples/Sharpmake.Samples.sharpmake.cs
@@ -117,6 +117,7 @@ namespace SharpmakeGen.Samples
         }
     }
 
+
     [Generate]
     public class DotNetCoreFrameworkHelloWorldProject : SampleProject
     {
@@ -234,4 +235,15 @@ namespace SharpmakeGen.Samples
             Name = "SimpleExeLibDependency";
         }
     }
+
+    [Generate]
+    public class PreBuildStepDependency : SampleProject
+    {
+        public PreBuildStepDependency()
+        {
+            Name = "PreBuildStepDependency";
+            SharpmakeMainFile = "PreBuildStepDependency.sharpmake.cs";
+        }
+    }
+
 }


### PR DESCRIPTION

By default pre-build steps of a dependency end up in the final project that added them as a dependency. I'm not sure if this is the intended behavior or not. This change adds:

-  overriding of build step inheritance behavior by using the `DependencySetting` enum. 
- Allow build order dependencies if the dependency is an exe. (Imagine a tool exe dependency for a pre-build step)
- Added a sample to demonstrate build steps issue

Not  sure if this code can be taken seeing as the pre build step default behavior might be wrong anyways. This is the fix I came up with which might drive a more complete fix.