### PR TITLE
Add support for Visual Studio 2019 /std:c11 and /std:c17 switches

### DIFF
--- a/Sharpmake.Generators/FastBuild/Bff.Template.cs
+++ b/Sharpmake.Generators/FastBuild/Bff.Template.cs
@@ -378,6 +378,7 @@ Compiler( '[fastbuildCompilerName]' )
             + ' [cmdLineOptions.RemoveUnreferencedCodeData]'
             + ' [cmdLineOptions.RuntimeTypeInfo]'
             + ' [cmdLineOptions.OpenMP]'
+            + ' [cmdLineOptions.LanguageStandard_C]'
             + ' [cmdLineOptions.LanguageStandard]'
             + ' [cmdLineOptions.ConformanceMode]'
             // Output Files options

--- a/Sharpmake.Generators/FastBuild/Bff.cs
+++ b/Sharpmake.Generators/FastBuild/Bff.cs
@@ -625,6 +625,9 @@ namespace Sharpmake.Generators.FastBuild
                             // Do not take Cpp Language conformance into account while compiling in C
                             scopedOptions.Add(new Options.ScopedOption(confCmdLineOptions, "CppLanguageStd", FileGeneratorUtilities.RemoveLineTag));
                             scopedOptions.Add(new Options.ScopedOption(confOptions, "ClangCppLanguageStandard", FileGeneratorUtilities.RemoveLineTag));
+                            // MSVC
+                            scopedOptions.Add(new Options.ScopedOption(confCmdLineOptions, "LanguageStandard", FileGeneratorUtilities.RemoveLineTag));
+
                             if (clangPlatformBff != null)
                                 clangFileLanguage = "-x c "; // Compiler option to indicate that its a C file
                             fastBuildSourceFileType = "/TC";
@@ -634,6 +637,8 @@ namespace Sharpmake.Generators.FastBuild
                             // Do not take C Language conformance into account while compiling in Cpp
                             scopedOptions.Add(new Options.ScopedOption(confCmdLineOptions, "CLanguageStd", FileGeneratorUtilities.RemoveLineTag));
                             scopedOptions.Add(new Options.ScopedOption(confOptions, "ClangCLanguageStandard", FileGeneratorUtilities.RemoveLineTag));
+                            // MSVC
+                            scopedOptions.Add(new Options.ScopedOption(confCmdLineOptions, "LanguageStandard_C", FileGeneratorUtilities.RemoveLineTag));
 
                             fastBuildSourceFileType = "/TP";
                             fastBuildUsingPlatformConfig = platformBff.CppConfigName(conf);

--- a/Sharpmake.Generators/VisualStudio/ProjectOptionsGenerator.cs
+++ b/Sharpmake.Generators/VisualStudio/ProjectOptionsGenerator.cs
@@ -368,6 +368,17 @@ namespace Sharpmake.Generators.VisualStudio
                 Options.Option(Options.Vc.Compiler.CppLanguageStandard.GNU17, () => { context.Options["LanguageStandard"] = "stdcpp17"; context.CommandLineOptions["LanguageStandard"] = "/std:c++17"; }),
                 Options.Option(Options.Vc.Compiler.CppLanguageStandard.Latest, () => { context.Options["LanguageStandard"] = "stdcpplatest"; context.CommandLineOptions["LanguageStandard"] = "/std:c++latest"; })
                 );
+
+                //Options.Vc.Compiler.CLanguageStandard.
+                //    Legacy                                  LanguageStandard_C=""
+                //    C11                                     LanguageStandard_C="stdc11"                                    /std:c11
+                //    C17                                     LanguageStandard_C="stdc17"                                    /std:c17
+                context.SelectOption
+                (
+                Options.Option(Options.Vc.Compiler.CLanguageStandard.Legacy, () => { context.Options["LanguageStandard_C"] = FileGeneratorUtilities.RemoveLineTag; context.CommandLineOptions["LanguageStandard_C"] = FileGeneratorUtilities.RemoveLineTag; }),
+                Options.Option(Options.Vc.Compiler.CLanguageStandard.C11,    () => { context.Options["LanguageStandard_C"] = "stdc11"; context.CommandLineOptions["LanguageStandard_C"] = "/std:c11"; }),
+                Options.Option(Options.Vc.Compiler.CLanguageStandard.C17,    () => { context.Options["LanguageStandard_C"] = "stdc17"; context.CommandLineOptions["LanguageStandard_C"] = "/std:c17"; })
+                );
             }
 
             // Compiler section

--- a/Sharpmake.Platforms/Sharpmake.CommonPlatforms/BasePlatform.Vcxproj.Template.cs
+++ b/Sharpmake.Platforms/Sharpmake.CommonPlatforms/BasePlatform.Vcxproj.Template.cs
@@ -62,6 +62,7 @@ namespace Sharpmake
       <ForceConformanceInForLoopScope>[options.ForceConformanceInForLoopScope]</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>[options.RuntimeTypeInfo]</RuntimeTypeInfo>
       <OpenMPSupport>[options.OpenMP]</OpenMPSupport>
+      <LanguageStandard_C>[options.LanguageStandard_C]</LanguageStandard_C>
       <LanguageStandard>[options.LanguageStandard]</LanguageStandard>
       <ExpandAttributedSource>false</ExpandAttributedSource>
       <AssemblerOutput>NoListing</AssemblerOutput>

--- a/Sharpmake/Options.Vc.cs
+++ b/Sharpmake/Options.Vc.cs
@@ -573,6 +573,16 @@ namespace Sharpmake
                     Latest
                 }
 
+                public enum CLanguageStandard
+                {
+                    [Default]
+                    Legacy,
+                    [DevEnvVersion(minimum = DevEnv.vs2019)]
+                    C11,
+                    [DevEnvVersion(minimum = DevEnv.vs2019)]
+                    C17
+                }
+
                 public enum SupportJustMyCode
                 {
                     [Default]


### PR DESCRIPTION
Visual Studio 2019 version 16.8.0 introduced /std:c11 and /std:c17 switches to set the C language standard. The 'Legacy' standard is used by default.