### PR TITLE
Add project EnableDefaultItems property

### DIFF
--- a/Sharpmake.Generators/VisualStudio/Csproj.cs
+++ b/Sharpmake.Generators/VisualStudio/Csproj.cs
@@ -1198,7 +1198,7 @@ namespace Sharpmake.Generators.VisualStudio
             string projectConfigurationCondition = Template.Project.DefaultProjectConfigurationCondition;
             if (isNetCoreProjectSchema)
             {
-                netCoreEnableDefaultItems = "false";
+                netCoreEnableDefaultItems = project.EnableDefaultItems.ToString();
                 targetFrameworkVersionString = "TargetFramework";
                 projectPropertyGuid = RemoveLineTag;
                 if (projectFrameworks.Count() > 1)

--- a/Sharpmake.Generators/VisualStudio/Csproj.cs
+++ b/Sharpmake.Generators/VisualStudio/Csproj.cs
@@ -1198,7 +1198,7 @@ namespace Sharpmake.Generators.VisualStudio
             string projectConfigurationCondition = Template.Project.DefaultProjectConfigurationCondition;
             if (isNetCoreProjectSchema)
             {
-                netCoreEnableDefaultItems = project.EnableDefaultItems.ToString();
+                netCoreEnableDefaultItems = project.EnableDefaultItems.ToString().ToLowerInvariant();
                 targetFrameworkVersionString = "TargetFramework";
                 projectPropertyGuid = RemoveLineTag;
                 if (projectFrameworks.Count() > 1)

--- a/Sharpmake/Project.cs
+++ b/Sharpmake/Project.cs
@@ -172,12 +172,7 @@ namespace Sharpmake
         public Strings NoneExtensionsCopyIfNewer = new Strings();
 
         public Strings XResourcesResw = new Strings();
-
-        /// <summary>
-        /// Enable or disable the property [EnableDefaultItems] in NetCore Project Schema
-        /// </summary>
-        public bool EnableDefaultItems { get; set; } = false;
-
+        
         public class XResourcesImgContainer : IEnumerable<string>
         {
             /// <summary>
@@ -2303,6 +2298,11 @@ namespace Sharpmake
         /// If set to true. Will explicit the RestoreProjectStyle in the project file
         /// </summary>
         public bool ExplicitNugetRestoreProjectStyle = false;
+
+        /// <summary>
+        /// Enable or disable the property [EnableDefaultItems] in NetCore Project Schema
+        /// </summary>
+        public bool EnableDefaultItems { get; set; } = false;
 
         public bool IncludeResxAsResources = true;
         public string RootNamespace;

--- a/Sharpmake/Project.cs
+++ b/Sharpmake/Project.cs
@@ -173,6 +173,8 @@ namespace Sharpmake
 
         public Strings XResourcesResw = new Strings();
 
+        public bool EnableDefaultItems { get; set; } = false;                           // Enable or disable the property [EnableDefaultItems] in NetCore Project Schema
+
         public class XResourcesImgContainer : IEnumerable<string>
         {
             /// <summary>

--- a/Sharpmake/Project.cs
+++ b/Sharpmake/Project.cs
@@ -172,7 +172,7 @@ namespace Sharpmake
         public Strings NoneExtensionsCopyIfNewer = new Strings();
 
         public Strings XResourcesResw = new Strings();
-        
+
         public class XResourcesImgContainer : IEnumerable<string>
         {
             /// <summary>

--- a/Sharpmake/Project.cs
+++ b/Sharpmake/Project.cs
@@ -173,7 +173,10 @@ namespace Sharpmake
 
         public Strings XResourcesResw = new Strings();
 
-        public bool EnableDefaultItems { get; set; } = false;                           // Enable or disable the property [EnableDefaultItems] in NetCore Project Schema
+        /// <summary>
+        /// Enable or disable the property [EnableDefaultItems] in NetCore Project Schema
+        /// </summary>
+        public bool EnableDefaultItems { get; set; } = false;
 
         public class XResourcesImgContainer : IEnumerable<string>
         {

--- a/samples/NetCore/DotNetCoreFrameworkHelloWorld/HelloWorld.sharpmake.cs
+++ b/samples/NetCore/DotNetCoreFrameworkHelloWorld/HelloWorld.sharpmake.cs
@@ -52,6 +52,7 @@ namespace NetCore
                 // This Path will be used to get all SourceFiles in this Folder and all subFolders
                 SourceRootPath = @"[project.SharpmakeCsPath]\codebase\[project.Name]";
                 AssemblyName = "the other name";
+                EnableDefaultItems = true;
             }
 
             [Configure()]


### PR DESCRIPTION
When creating netCore solution that uses launchSettings.json, if the project property `EnableDefaultItems` is false when the project start it won't use the the LaunchSettings.

I created a new project property called `EnableDefaultItems` (default value is false as before) in which allow to pass true and use EnableDefaultItems as true in the project and then we can use launchSettings.json when start the project. 

![image](https://user-images.githubusercontent.com/2362515/115885294-d3d6ab00-a41d-11eb-8ac6-2403f957085d.png)
