### PR TITLE
Fixing invalid /sources command line parameters in the csproj.user file created via /generateDebugSolution

### DIFF
--- a/Sharpmake/DebugProjectGenerator.cs
+++ b/Sharpmake/DebugProjectGenerator.cs
@@ -253,7 +253,7 @@ namespace Sharpmake
             conf.CsprojUserFile.StartAction = Project.Configuration.CsprojUserFileSettings.StartActionSetting.Program;
 
             string quote = "\'"; // Use single quote that is cross platform safe
-            conf.CsprojUserFile.StartArguments = $@"/sources(@{quote}{string.Join(";", MainSources)}{quote}) {startArguments}";
+            conf.CsprojUserFile.StartArguments = $@"/sources(@{quote}{string.Join($"{quote},@{quote}", MainSources)}{quote}) {startArguments}";
             conf.CsprojUserFile.StartProgram = DebugProjectExtension.GetSharpmakeExecutableFullPath();
         }
     }


### PR DESCRIPTION
The fixed format is:

/sources(@'d:\folder\file1.sharpmake.cs',@'d:\anotherfolder\anotherfile.sharpmake.cs')

Previously the command line parameters were created in this format:

/sources(@'d:\folder\file1.sharpmake.cs;d:\anotherfolder\anotherfile.sharpmake.cs')

which results in the following exception when running the generated project:

 The given path's format is not supported.

 Stack trace:
 Root stack trace:
   at System.Security.Permissions.FileIOPermission.EmulateFileIOPermissionChecks(String fullPath)
   at System.Security.Permissions.FileIOPermission.QuickDemand(FileIOPermissionAccess access, String fullPath, Boolean checkForDuplicates, Boolean needFullPath)
   at System.IO.Path.GetFullPath(String path)
   at Sharpmake.Application.Program.Argument.ValidateFiles(String[] files) in d:\github\sharpmake\Sharpmake.Application\CommandLineArguments.cs:line 395
   at Sharpmake.Application.Program.Argument.SetSources(String[] files) in d:\github\sharpmake\Sharpmake.Application\CommandLineArguments.cs:line 77

Fixes #125 