### PR TITLE
Resolve AdditionalSourceRootPaths before use

### DIFF
--- a/Sharpmake/Project.cs
+++ b/Sharpmake/Project.cs
@@ -1820,6 +1820,7 @@ namespace Sharpmake
                 // Resolve full paths
                 _rootPath = Util.SimplifyPath(RootPath);
                 Util.ResolvePath(SharpmakeCsPath, ref _sourceRootPath);
+                Util.ResolvePath(SharpmakeCsPath, ref AdditionalSourceRootPaths);
                 Util.ResolvePath(SourceRootPath, ref SourceFiles);
                 Util.ResolvePath(SourceRootPath, ref SourceFilesExclude);
                 Util.ResolvePath(SourceRootPath, ref SourceFilesBlobExclude);

--- a/samples/HelloXCode/HelloXCode.CommonProject.sharpmake.cs
+++ b/samples/HelloXCode/HelloXCode.CommonProject.sharpmake.cs
@@ -38,12 +38,15 @@ namespace HelloXCode
             IsTargetFileNameToLower = false;
 
             SourceRootPath = @"[project.RootPath]\[project.Name]";
+            AdditionalSourceRootPaths.Add(Globals.ExternalDirectory);
         }
 
         [ConfigurePriority(ConfigurePriorities.All)]
         [Configure]
         public virtual void ConfigureAll(Configuration conf, CommonTarget target)
         {
+            conf.IncludePaths.Add(Globals.ExternalDirectory);
+
             conf.ProjectFileName = "[project.Name]_[target.Platform]";
             if (target.DevEnv != DevEnv.xcode4ios)
                 conf.ProjectFileName += "_[target.DevEnv]";

--- a/samples/HelloXCode/HelloXCode.Main.sharpmake.cs
+++ b/samples/HelloXCode/HelloXCode.Main.sharpmake.cs
@@ -36,6 +36,7 @@ namespace HelloXCode
         public static string RootDirectory;
         public static string TmpDirectory { get { return Path.Combine(RootDirectory, "temp"); } }
         public static string OutputDirectory { get { return Path.Combine(TmpDirectory, "bin"); } }
+        public static string ExternalDirectory { get { return Path.Combine(RootDirectory, @"..\external"); } }
     }
 
     public static class Main

--- a/samples/HelloXCode/codebase/dll1/util_dll.cpp
+++ b/samples/HelloXCode/codebase/dll1/util_dll.cpp
@@ -3,6 +3,7 @@
 
 #include "src/util_static_lib1.h"
 #include <iostream>
+#include <external.h>
 
 int UtilDll1::ComputeSum(const std::vector<int>& someInts)
 {
@@ -10,21 +11,7 @@ int UtilDll1::ComputeSum(const std::vector<int>& someInts)
     for (int item : someInts)
         acc += item;
 
-#if _DEBUG
-    std::cout << "- Dll1 is built in Debug"
-#  if USES_FASTBUILD
-        " with FastBuild"
-#  endif
-        "!" << std::endl;
-#endif
-
-#if NDEBUG
-    std::cout << "- Dll1 is built in Release"
-#  if USES_FASTBUILD
-        " with FastBuild"
-#  endif
-        "!" << std::endl;
-#endif
+    PrintBuildString("Dll1");
 
     acc += static_lib1_utils::GetRandomPosition();
     

--- a/samples/HelloXCode/codebase/exe/main.cpp
+++ b/samples/HelloXCode/codebase/exe/main.cpp
@@ -3,25 +3,13 @@
 #include "util_static_lib2.h"
 #include "sub folder/useless_static_lib2.h"
 
+#include <external.h>
+
 int main(int, char**)
 {
     std::cout << "Hello XCode World, from " CREATION_DATE "!" << std::endl;
 
-#if _DEBUG
-    std::cout << "- Exe is built in Debug"
-#  if USES_FASTBUILD
-        " with FastBuild"
-#  endif
-        "!" << std::endl;
-#endif
-
-#if NDEBUG
-    std::cout << "- Exe is built in Release"
-#  if USES_FASTBUILD
-        " with FastBuild"
-#  endif
-        "!" << std::endl;
-#endif
+    PrintBuildString("Exe");
 
     std::vector<int> someArray(5, 6);
 

--- a/samples/HelloXCode/codebase/static lib2/util_static_lib2.cpp
+++ b/samples/HelloXCode/codebase/static lib2/util_static_lib2.cpp
@@ -1,5 +1,6 @@
 #include "util_static_lib2.h"
 #include <iostream>
+#include <external.h>
 
 Util2::Util2() = default;
 
@@ -9,21 +10,7 @@ Util2::~Util2()
 
 void Util2::DoSomethingUseful() const
 {
-#if _DEBUG
-    std::cout << "- StaticLib2 is built in Debug"
-#  if USES_FASTBUILD
-        " with FastBuild"
-#  endif
-        "!" << std::endl;
-#endif
-
-#if NDEBUG
-    std::cout << "- StaticLib2 is built in Release"
-#  if USES_FASTBUILD
-        " with FastBuild"
-#  endif
-        "!" << std::endl;
-#endif
+    PrintBuildString("StaticLib2");
 
     return DoSomethingInternal("Yeah right...");
 }

--- a/samples/HelloXCode/codebase/static_lib1/src/util_static_lib1.cpp
+++ b/samples/HelloXCode/codebase/static_lib1/src/util_static_lib1.cpp
@@ -1,26 +1,13 @@
 #include "src/pch.h"
 #include "util_static_lib1.h"
 #include <ios>
+#include <external.h>
 
 namespace static_lib1_utils
 {
     std::streampos GetRandomPosition()
     {
-#if _DEBUG
-    std::cout << "- StaticLib1 is built in Debug"
-#  if USES_FASTBUILD
-        " with FastBuild"
-#  endif
-        "!" << std::endl;
-#endif
-
-#if NDEBUG
-    std::cout << "- StaticLib1 is built in Release"
-#  if USES_FASTBUILD
-        " with FastBuild"
-#  endif
-        "!" << std::endl;
-#endif
+        PrintBuildString("StaticLib1");
 
         return 1;
     }

--- a/samples/HelloXCode/external/external.cpp
+++ b/samples/HelloXCode/external/external.cpp
@@ -1,0 +1,20 @@
+#include "external.h"
+#include <iostream>
+
+void PrintBuildString(const char* binaryName)
+{
+#if _DEBUG
+    const char* configName = "Debug";
+#elif NDEBUG
+    const char* configName = "Release";
+#endif
+
+    std::cout << "- " <<
+        binaryName <<
+        " is built in " <<
+        configName <<
+#if USES_FASTBUILD
+        " with FastBuild"
+#endif
+        "!" << std::endl;
+}

--- a/samples/HelloXCode/external/external.h
+++ b/samples/HelloXCode/external/external.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void PrintBuildString(const char* binaryName);


### PR DESCRIPTION
The AdditionalSourceRootPaths member never had the paths it contained resolved, resulting in paths that had mixed folder separators to not be looked up correctly inside of ResolveSourceFiles.

Ex: A path added to AdditionalSourcerootPaths on Mac OSX set as:

@"[project.SharpmakeCsPath]\..\externals\SomeExternal"

that expanded to:

/Users/SomeUser/Documents/SomeProject/sharpmake\\..\\externals\\SomeExternal

would fail to have the files in the directory looked up. Calling ResolvePath on the member causes the path to be normalized to:

/Users/SomeUser/Documents/SomeProject/externals/SomeExternal