### PR TITLE
Fixing custom build step generation for FastBuild

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -159,6 +159,14 @@ jobs:
           & $env:SHARPMAKE_EXE "/sources('CSharpVsix.sharpmake.cs')"
           & $env:COMPILE_BATCH projects\CSharpVsixSolution.vs2017.v4_7_2.sln "${{ matrix.configuration }}" "Any CPU"
 
+      - name: CustomBuildStep ${{ matrix.configuration }}
+        if: runner.os == 'Windows'
+        working-directory: 'samples/CustomBuildStep'
+        run: | 
+          & $env:SHARPMAKE_EXE "/sources('CustomBuildStep.sharpmake.cs')"
+          & $env:COMPILE_BATCH projects\custombuildstepsolution_vs2017_win64.sln "${{ matrix.configuration }}" "x64"
+          projects\output\win64\${{ matrix.configuration }}\custombuildstep.exe
+
       - name: CSharpWCF ${{ matrix.configuration }}
         if: runner.os == 'Windows'
         working-directory: 'samples/CSharpWCF'

--- a/Sharpmake.Generators/FastBuild/Bff.Util.cs
+++ b/Sharpmake.Generators/FastBuild/Bff.Util.cs
@@ -678,7 +678,7 @@ namespace Sharpmake.Generators.FastBuild
             return strBuilder.ToString();
         }
 
-        internal static void WriteCustomBuildStepAsGenericExecutable(string projectRoot, FileGenerator bffGenerator, Project.Configuration.CustomFileBuildStep buildStep, Func<string, bool> functor)
+        internal static void WriteCustomBuildStepAsGenericExecutable(string projectRoot, FileGenerator bffGenerator, Project.Configuration.CustomFileBuildStep buildStep, Func<Project.Configuration.CustomFileBuildStepData, bool> functor)
         {
             var relativeBuildStep = buildStep.MakePathRelative(bffGenerator.Resolver,
                 (path, commandRelative) =>
@@ -699,12 +699,14 @@ namespace Sharpmake.Generators.FastBuild
             using (bffGenerator.Declare("fastBuildPrebuildWorkingPath", FileGeneratorUtilities.RemoveLineTag))
             using (bffGenerator.Declare("fastBuildPrebuildUseStdOutAsOutput", FileGeneratorUtilities.RemoveLineTag))
             using (bffGenerator.Declare("fastBuildPrebuildAlwaysShowOutput", FileGeneratorUtilities.RemoveLineTag))
+            using (bffGenerator.Declare("fastBuildExecPreBuildDependencies", FileGeneratorUtilities.RemoveLineTag))
+            using (bffGenerator.Declare("fastBuildExecAlways", "true"))
             {
-                functor(relativeBuildStep.Description);
+                functor(relativeBuildStep);
             }
         }
 
-        internal static void WriteConfigCustomBuildStepsAsGenericExecutable(string projectRoot, FileGenerator bffGenerator, Project project, Project.Configuration config, Func<string, bool> functor)
+        internal static void WriteConfigCustomBuildStepsAsGenericExecutable(string projectRoot, FileGenerator bffGenerator, Project project, Project.Configuration config, Func<Project.Configuration.CustomFileBuildStepData, bool> functor)
         {
             using (bffGenerator.Resolver.NewScopedParameter("project", project))
             using (bffGenerator.Resolver.NewScopedParameter("config", config))

--- a/samples/CustomBuildStep/CustomBuildStep.sharpmake.cs
+++ b/samples/CustomBuildStep/CustomBuildStep.sharpmake.cs
@@ -1,0 +1,111 @@
+﻿// Copyright (c) 2021 Ubisoft Entertainment
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Sharpmake;
+
+namespace FastBuild
+{
+    [Sharpmake.Generate]
+    public class CustomBuildStepProject : Project
+    {
+        public CustomBuildStepProject()
+        {
+            Name = "CustomBuildStep";
+            SourceRootPath = @"[project.SharpmakeCsPath]\codebase";
+            SourceFilesExtensions.Add(".bat");
+
+            // need to add it explicitly since it's gonna be generated it doesn't exist yet
+            SourceFiles.Add(@"[project.SourceRootPath]\main.cpp");
+
+            AddTargets(
+                new Target(
+                    Platform.win64,
+                    DevEnv.vs2017,
+                    Optimization.Debug | Optimization.Release,
+                    OutputType.Lib,
+                    Blob.NoBlob,
+                    BuildSystem.MSBuild | BuildSystem.FastBuild
+                )
+            );
+        }
+
+        [Configure]
+        public void ConfigureAll(Configuration conf, Target target)
+        {
+            conf.CustomFileBuildSteps.Add(
+                new Configuration.CustomFileBuildStep {
+                    KeyInput = "filegeneration.bat",
+                    Output = "main.cpp",
+                    Description = $"Generate main.cpp",
+                    Executable = "filegeneration.bat"
+                }
+            );
+
+            conf.ProjectFileName = "[project.Name]_[target.DevEnv]_[target.Platform]";
+            conf.ProjectPath = @"[project.SharpmakeCsPath]\projects";
+        }
+
+        [Configure(BuildSystem.FastBuild)]
+        public void ConfigureFastBuild(Configuration conf, Target target)
+        {
+            conf.Name = "FastBuild " + conf.Name;
+            conf.IsFastBuild = true;
+            conf.FastBuildBlobbed = target.Blob == Blob.FastBuildUnitys;
+        }
+    }
+
+    [Sharpmake.Generate]
+    public class CustomBuildStepSolution : Sharpmake.Solution
+    {
+        public CustomBuildStepSolution()
+        {
+            Name = "CustomBuildStepSolution";
+
+            AddTargets(
+                new Target(
+                    Platform.win64,
+                    DevEnv.vs2017,
+                    Optimization.Debug | Optimization.Release,
+                    OutputType.Lib,
+                    Blob.NoBlob,
+                    BuildSystem.MSBuild | BuildSystem.FastBuild
+                )
+            );
+        }
+
+        [Configure()]
+        public void ConfigureAll(Configuration conf, Target target)
+        {
+            conf.SolutionFileName = "[solution.Name]_[target.DevEnv]_[target.Platform]";
+            conf.SolutionPath = @"[solution.SharpmakeCsPath]\projects";
+
+            conf.AddProject<CustomBuildStepProject>(target);
+        }
+
+        [Configure(BuildSystem.FastBuild)]
+        public void ConfigureFastBuild(Configuration conf, Target target)
+        {
+            conf.Name = "FastBuild " + conf.Name;
+        }
+
+        [Sharpmake.Main]
+        public static void SharpmakeMain(Sharpmake.Arguments arguments)
+        {
+            FastBuildSettings.FastBuildMakeCommand = @"..\..\..\tools\FastBuild\Windows-x64\FBuild.exe";
+            KitsRootPaths.SetUseKitsRootForDevEnv(DevEnv.vs2017, KitsRootEnum.KitsRoot10, Options.Vc.General.WindowsTargetPlatformVersion.v10_0_17763_0);
+
+            arguments.Generate<CustomBuildStepSolution>();
+        }
+    }
+}

--- a/samples/CustomBuildStep/Properties/AssemblyInfo.cs
+++ b/samples/CustomBuildStep/Properties/AssemblyInfo.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) 2021 Ubisoft Entertainment
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("CustomBuildStep")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Ubisoft")]
+[assembly: AssemblyProduct("CustomBuildStep")]
+[assembly: AssemblyCopyright("Copyright \u00A9 Ubisoft 2021")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("de3e6399-3aec-4f3c-854d-b6311f3fdc92")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/samples/CustomBuildStep/codebase/filegeneration.bat
+++ b/samples/CustomBuildStep/codebase/filegeneration.bat
@@ -1,0 +1,7 @@
+@echo off
+SET FILENAME=%~dp0\main.cpp
+
+echo int main(int, char**) > %FILENAME%
+echo { >> %FILENAME%
+echo 	return 0; >> %FILENAME%
+echo } >> %FILENAME%

--- a/samples/Sharpmake.Samples.sharpmake.cs
+++ b/samples/Sharpmake.Samples.sharpmake.cs
@@ -118,6 +118,15 @@ namespace SharpmakeGen.Samples
     }
 
     [Generate]
+    public class CustomBuildStepProject : SampleProject
+    {
+        public CustomBuildStepProject()
+        {
+            Name = "CustomBuildStep";
+        }
+    }
+
+    [Generate]
     public class DotNetCoreFrameworkHelloWorldProject : SampleProject
     {
         public DotNetCoreFrameworkHelloWorldProject()


### PR DESCRIPTION
- Adding missing variables to the "Declare"
- Fix multiple "Exec" with same output by adding it only once. Added validations to make sure each one has the exact same settings
- Adding a new sample that test CustomBuildStep. At build (from FastBuild or from MSBuild), the filegeneration.bat should be called before building the project. It is generating the "main.cpp".