### PR TITLE
[MasterBff] Fix target copy files of dependencies

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -210,6 +210,16 @@ jobs:
           & $env:COMPILE_BATCH codebase\temp\solutions\HelloClangCl_win64_vs2019.sln "MSVC ${{ matrix.configuration }}" "FastBuild"
           codebase\temp\bin\win64_msvc_${{ matrix.configuration }}_fastbuild\exe_rx.exe
 
+      - name: HelloEvents
+        if: runner.os == 'Windows'
+        working-directory: 'samples/HelloEvents'
+        run: |
+          & $env:SHARPMAKE_EXE "/sources('HelloEvents.Main.sharpmake.cs')"
+          & $env:COMPILE_BATCH codebase\temp\solutions\HelloEvents_win64_vs2019.sln "${{ matrix.configuration }}" "win64"
+          codebase\temp\bin\win64_${{ matrix.configuration }}\exe\exe.exe
+          & $env:COMPILE_BATCH codebase\temp\solutions\HelloEvents_win64_vs2019.sln "${{ matrix.configuration }}_FastBuild" "win64"
+          codebase\temp\bin\win64_${{ matrix.configuration }}_fastbuild\exe\exe.exe
+
       - name: HelloLinux ${{ matrix.configuration }}
         if: runner.os == 'Linux'
         working-directory: 'samples/HelloLinux'

--- a/Sharpmake.Generators/FastBuild/MasterBff.cs
+++ b/Sharpmake.Generators/FastBuild/MasterBff.cs
@@ -247,6 +247,31 @@ namespace Sharpmake.Generators.FastBuild
             }
         }
 
+        private static void RegisterBuiltOutputsForConf(
+            Project.Configuration conf,
+            string fastBuildTargetIdentifier,
+            Dictionary<string, (string sourceBff, string sourceNodeIdentifier)> outputsByBffAndNode
+        )
+        {
+            string bffFullPath = Util.GetCapitalizedPath(conf.BffFullFileName) + FastBuildSettings.FastBuildConfigFileExtension;
+
+            void registerOutputAndCheck(string outputFile)
+            {
+                if (!outputsByBffAndNode.TryGetValue(outputFile, out var pair))
+                {
+                    outputsByBffAndNode.Add(outputFile, (bffFullPath, fastBuildTargetIdentifier));
+                }
+                else if (FileSystemStringComparer.StaticCompare(pair.sourceBff, bffFullPath) != 0 || pair.sourceNodeIdentifier != fastBuildTargetIdentifier)
+                {
+                    throw new Error("Found identical output from multiple sources!");
+                }
+            }
+
+
+            registerOutputAndCheck(conf.LinkerPdbFilePath);
+            registerOutputAndCheck(Path.Combine(conf.TargetPath, conf.TargetFileFullNameWithExtension));
+        }
+
         private static bool GenerateMasterBffFile(Builder builder, ConfigurationsPerBff configurationsPerBff)
         {
             configurationsPerBff.Sort();
@@ -275,7 +300,7 @@ namespace Sharpmake.Generators.FastBuild
 
             var bffPreBuildSection = new Dictionary<string, string>();
             var bffCustomPreBuildSection = new Dictionary<string, string>();
-            var bffMasterSection = new Dictionary<string, string>();
+            var bffCopyNodes = new Dictionary<string, (string sourceFullPath, string src, string dest)>();
             var masterBffCopySections = new List<string>();
             var masterBffCustomSections = new UniqueList<string>(); // section that is not ordered
 
@@ -284,6 +309,7 @@ namespace Sharpmake.Generators.FastBuild
             var platformBffCache = new Dictionary<Platform, IPlatformBff>();
 
             var verificationPostBuildCopies = new Dictionary<string, string>();
+            var outputsByBffAndNode = new Dictionary<string, (string sourceBff, string sourceNodeIdentifier)>(FileSystemStringComparer.Default);
             foreach (Solution.Configuration solutionConfiguration in configurationsPerBff)
             {
                 foreach (var solutionProject in solutionProjects)
@@ -314,8 +340,10 @@ namespace Sharpmake.Generators.FastBuild
 
                     platformBff.AddCompilerSettings(masterBffInfo.CompilerSettings, conf);
 
+                    string fastBuildTargetIdentifier = Bff.GetShortProjectName(project, conf);
+
                     if (FastBuildSettings.WriteAllConfigsSection && includedProject.ToBuild == Solution.Configuration.IncludedProjectInfo.Build.Yes)
-                        masterBffInfo.AllConfigsSections.Add(Bff.GetShortProjectName(project, conf));
+                        masterBffInfo.AllConfigsSections.Add(fastBuildTargetIdentifier);
 
                     bool isOutputTypeExe = conf.Output == Project.Configuration.OutputType.Exe;
                     bool isOutputTypeDll = conf.Output == Project.Configuration.OutputType.Dll;
@@ -329,6 +357,8 @@ namespace Sharpmake.Generators.FastBuild
                         var preBuildEvents = new Dictionary<string, Project.Configuration.BuildStepBase>();
                         if (isOutputTypeExeOrDll || conf.ExecuteTargetCopy)
                         {
+                            RegisterBuiltOutputsForConf(conf, fastBuildTargetIdentifier, outputsByBffAndNode);
+
                             var copies = ProjectOptionsGenerator.ConvertPostBuildCopiesToRelative(conf, masterBffDirectory);
                             foreach (var copy in copies)
                             {
@@ -340,12 +370,13 @@ namespace Sharpmake.Generators.FastBuild
                                 // use the global root for alias computation, as the project has not idea in which master bff it has been included
                                 var destinationRelativeToGlobal = Util.GetConvertedRelativePath(masterBffDirectory, destinationFolder, conf.Project.RootPath, true, conf.Project.RootPath);
 
+                                string fastBuildCopyAlias = UtilityMethods.GetFastBuildCopyAlias(sourceFileName, destinationRelativeToGlobal);
+                                string currentSourceFullPath = Util.PathGetAbsolute(masterBffDirectory, sourceFile);
+
                                 if (FastBuildSettings.FastBuildValidateCopyFiles)
                                 {
                                     string key = sourceFileName + destinationRelativeToGlobal;
-                                    string currentSourceFullPath = Util.PathGetAbsolute(masterBffDirectory, sourceFile);
-                                    string previous;
-                                    if (verificationPostBuildCopies.TryGetValue(key, out previous))
+                                    if (verificationPostBuildCopies.TryGetValue(key, out var previous))
                                     {
                                         if (FileSystemStringComparer.StaticCompare(previous, currentSourceFullPath) != 0)
                                             builder.LogErrorLine("A post-build copy to the destination '{0}' already exist but from different sources: '{1}' and '{2}'!", Util.PathGetAbsolute(masterBffDirectory, destinationFolder), previous, currentSourceFullPath);
@@ -356,17 +387,8 @@ namespace Sharpmake.Generators.FastBuild
                                     }
                                 }
 
-                                string fastBuildCopyAlias = UtilityMethods.GetFastBuildCopyAlias(sourceFileName, destinationRelativeToGlobal);
-                                {
-                                    using (fileGenerator.Declare("fastBuildCopyAlias", fastBuildCopyAlias))
-                                    using (fileGenerator.Declare("fastBuildCopySource", Bff.CurrentBffPathKeyCombine(sourceFile)))
-                                    using (fileGenerator.Declare("fastBuildCopyDest", Bff.CurrentBffPathKeyCombine(destinationFile)))
-                                    using (fileGenerator.Declare("fastBuildCopyDependencies", FileGeneratorUtilities.RemoveLineTag))
-                                    {
-                                        if (!bffMasterSection.ContainsKey(fastBuildCopyAlias))
-                                            bffMasterSection.Add(fastBuildCopyAlias, fileGenerator.Resolver.Resolve(Bff.Template.ConfigurationFile.CopyFileSection));
-                                    }
-                                }
+                                if (!bffCopyNodes.ContainsKey(fastBuildCopyAlias))
+                                    bffCopyNodes.Add(fastBuildCopyAlias, (currentSourceFullPath, Bff.CurrentBffPathKeyCombine(sourceFile), Bff.CurrentBffPathKeyCombine(destinationFile)));
                             }
                         }
 
@@ -404,23 +426,34 @@ namespace Sharpmake.Generators.FastBuild
             if (!mustGenerateFastbuild)
                 throw new Error("Sharpmake-FastBuild : Trying to generate a MasterBff with none of its projects having a FastBuild configuration, or having a platform supporting it, or all of them having conf.DoNotGenerateFastBuild = true");
 
-            masterBffCopySections.AddRange(bffMasterSection.Values);
+            var afterBffCopies = new Dictionary<string, List<string>>();
+            foreach (var copyNode in bffCopyNodes)
+            {
+                bool foundTargetInBff = outputsByBffAndNode.TryGetValue(copyNode.Value.sourceFullPath, out var bffAndNode);
+                using (fileGenerator.Declare("fastBuildCopyAlias", copyNode.Key))
+                using (fileGenerator.Declare("fastBuildCopySource", copyNode.Value.src))
+                using (fileGenerator.Declare("fastBuildCopyDest", copyNode.Value.dest))
+                using (fileGenerator.Declare("fastBuildCopyDependencies", foundTargetInBff ? $"'{bffAndNode.sourceNodeIdentifier}'" : FileGeneratorUtilities.RemoveLineTag))
+                {
+                    string nodeContent = fileGenerator.Resolver.Resolve(Bff.Template.ConfigurationFile.CopyFileSection);
+
+                    if (!foundTargetInBff)
+                    {
+                        masterBffCopySections.Add(nodeContent);
+                    }
+                    else
+                    {
+                        if (!afterBffCopies.ContainsKey(bffAndNode.sourceBff))
+                            afterBffCopies.Add(bffAndNode.sourceBff, new List<string> { nodeContent });
+                        else
+                            afterBffCopies[bffAndNode.sourceBff].Add(nodeContent);
+                    }
+                }
+            }
+
             masterBffCopySections.AddRange(bffPreBuildSection.Values);
 
             masterBffCustomSections.AddRange(bffCustomPreBuildSection.Values);
-
-            var result = new StringBuilder();
-            foreach (var projectBffFullPath in GetMasterIncludeList(masterBffInfo.BffIncludeToDependencyIncludes))
-            {
-                string projectFullPath = Path.GetDirectoryName(projectBffFullPath);
-                var projectPathRelativeFromMasterBff = Util.PathGetRelative(masterBffDirectory, projectFullPath, true);
-
-                string bffKeyRelative = Path.Combine(projectPathRelativeFromMasterBff, Path.GetFileName(projectBffFullPath));
-
-                result.AppendLine($"#include \"{bffKeyRelative}\"");
-            }
-
-            string fastBuildMasterBffDependencies = result.Length == 0 ? FileGeneratorUtilities.RemoveLineTag : result.ToString();
 
             GenerateMasterBffGlobalSettingsFile(builder, globalConfigFullPath, masterBffInfo);
 
@@ -438,6 +471,29 @@ namespace Sharpmake.Generators.FastBuild
 
             WriteMasterCopySection(fileGenerator, masterBffCopySections);
             WriteMasterCustomSection(fileGenerator, masterBffCustomSections);
+
+            var result = new StringBuilder();
+            foreach (var projectBffFullPath in GetMasterIncludeList(masterBffInfo.BffIncludeToDependencyIncludes))
+            {
+                string projectFullPath = Path.GetDirectoryName(projectBffFullPath);
+                var projectPathRelativeFromMasterBff = Util.PathGetRelative(masterBffDirectory, projectFullPath, true);
+
+                string bffKeyRelative = Path.Combine(projectPathRelativeFromMasterBff, Path.GetFileName(projectBffFullPath));
+
+                result.AppendLine($"#include \"{bffKeyRelative}\"");
+
+                if (afterBffCopies.TryGetValue(projectBffFullPath, out List<string> copyNodes))
+                {
+                    foreach (var copyNode in copyNodes)
+                        result.Append(copyNode);
+                    afterBffCopies.Remove(projectBffFullPath); // not necessary but just to verify that we wrote all we wanted
+                }
+            }
+
+            if (afterBffCopies.Count > 0)
+                throw new Error("The target source of some postbuild copies was not included in the master bff!");
+
+            string fastBuildMasterBffDependencies = result.Length == 0 ? FileGeneratorUtilities.RemoveLineTag : result.ToString();
 
             using (fileGenerator.Declare("fastBuildProjectName", masterBffFileName))
             using (fileGenerator.Declare("fastBuildOrderedBffDependencies", fastBuildMasterBffDependencies))

--- a/samples/HelloEvents/HelloEvents.CommonProject.sharpmake.cs
+++ b/samples/HelloEvents/HelloEvents.CommonProject.sharpmake.cs
@@ -1,0 +1,149 @@
+﻿// Copyright (c) 2021 Ubisoft Entertainment
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.IO;
+using System.Linq;
+using Sharpmake;
+
+namespace HelloEvents
+{
+    public static class ConfigurePriorities
+    {
+        public const int All = -75;
+        public const int Platform = -50;
+        public const int Optimization = -25;
+        /*     SHARPMAKE DEFAULT IS 0     */
+        public const int Blobbing = 25;
+        public const int BuildSystem = 50;
+    }
+
+    public abstract class CommonProject : Sharpmake.Project
+    {
+        protected CommonProject()
+            : base(typeof(CommonTarget))
+        {
+            RootPath = Globals.RootDirectory;
+            IsFileNameToLower = false;
+            IsTargetFileNameToLower = false;
+
+            SourceRootPath = @"[project.RootPath]\[project.Name]";
+        }
+
+        [ConfigurePriority(ConfigurePriorities.All)]
+        [Configure]
+        public virtual void ConfigureAll(Configuration conf, CommonTarget target)
+        {
+            conf.ProjectFileName = "[project.Name]_[target.Platform]";
+            if (target.DevEnv != DevEnv.xcode4ios)
+                conf.ProjectFileName += "_[target.DevEnv]";
+            conf.ProjectPath = Path.Combine(Globals.TmpDirectory, @"projects\[project.Name]");
+            conf.IsFastBuild = target.BuildSystem == BuildSystem.FastBuild;
+
+            conf.IntermediatePath = Path.Combine(Globals.TmpDirectory, @"obj\[target.DirectoryName]\[project.Name]");
+
+            // intentionally put all of the project outputs in their own directory
+            conf.TargetPath = Path.Combine(Globals.OutputDirectory, @"[target.DirectoryName]\[project.Name]");
+
+            conf.TargetLibraryPath = Path.Combine(Globals.TmpDirectory, @"lib\[target.DirectoryName]\[project.Name]");
+
+            conf.Output = Configuration.OutputType.Lib; // defaults to creating static libs
+
+            conf.Options.Add(Options.Vc.Compiler.CppLanguageStandard.CPP17);
+
+            conf.Options.Add(Options.Vc.General.TreatWarningsAsErrors.Enable);
+
+            conf.Options.Add(Options.Vc.Linker.GenerateMapFile.Disable);
+        }
+
+        ////////////////////////////////////////////////////////////////////////
+        #region Platfoms
+        [ConfigurePriority(ConfigurePriorities.Platform)]
+        [Configure(Platform.win64)]
+        public virtual void ConfigureWin64(Configuration conf, CommonTarget target)
+        {
+            conf.Defines.Add("_HAS_EXCEPTIONS=0");
+        }
+        #endregion
+        ////////////////////////////////////////////////////////////////////////
+
+        ////////////////////////////////////////////////////////////////////////
+        #region Optimizations
+        [ConfigurePriority(ConfigurePriorities.Optimization)]
+        [Configure(Optimization.Debug)]
+        public virtual void ConfigureDebug(Configuration conf, CommonTarget target)
+        {
+            conf.DefaultOption = Options.DefaultTarget.Debug;
+        }
+
+        [ConfigurePriority(ConfigurePriorities.Optimization)]
+        [Configure(Optimization.Release)]
+        public virtual void ConfigureRelease(Configuration conf, CommonTarget target)
+        {
+            conf.DefaultOption = Options.DefaultTarget.Release;
+        }
+        #endregion
+        ////////////////////////////////////////////////////////////////////////
+
+        ////////////////////////////////////////////////////////////////////////
+        #region Blobs and unitys
+        [Configure(Blob.FastBuildUnitys)]
+        [ConfigurePriority(ConfigurePriorities.Blobbing)]
+        public virtual void FastBuildUnitys(Configuration conf, CommonTarget target)
+        {
+            conf.FastBuildBlobbed = true;
+            conf.FastBuildUnityPath = Path.Combine(Globals.TmpDirectory, @"unity\[project.Name]");
+            conf.IncludeBlobbedSourceFiles = false;
+            conf.IsBlobbed = false;
+        }
+
+        [Configure(Blob.NoBlob)]
+        [ConfigurePriority(ConfigurePriorities.Blobbing)]
+        public virtual void BlobNoBlob(Configuration conf, CommonTarget target)
+        {
+            conf.FastBuildBlobbed = false;
+            conf.IsBlobbed = false;
+
+            if (conf.IsFastBuild)
+                conf.ProjectName += "_NoBlob";
+        }
+        #endregion
+        ////////////////////////////////////////////////////////////////////////
+
+        ////////////////////////////////////////////////////////////////////////
+        #region Build system
+        [ConfigurePriority(ConfigurePriorities.BuildSystem)]
+        [Configure(BuildSystem.MSBuild)]
+        public virtual void ConfigureMSBuild(Configuration conf, CommonTarget target)
+        {
+            // starting with vs2019 16.10, need this to fix warning: argument unused during compilation: '/MP'
+            conf.Options.Add(Options.Vc.Compiler.MultiProcessorCompilation.Disable);
+        }
+
+        [ConfigurePriority(ConfigurePriorities.BuildSystem)]
+        [Configure(BuildSystem.FastBuild)]
+        public virtual void ConfigureFastBuild(Configuration conf, CommonTarget target)
+        {
+            conf.SolutionFolder = "FastBuild/" + conf.SolutionFolder;
+            conf.ProjectName += "_FastBuild";
+            conf.ProjectFileName += "_FastBuild";
+
+            conf.Defines.Add("USES_FASTBUILD");
+
+            // Force writing to pdb from different cl.exe process to go through the pdb server
+            conf.AdditionalCompilerOptions.Add("/FS");
+        }
+        #endregion
+        ////////////////////////////////////////////////////////////////////////
+    }
+}

--- a/samples/HelloEvents/HelloEvents.CommonSolution.sharpmake.cs
+++ b/samples/HelloEvents/HelloEvents.CommonSolution.sharpmake.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) 2021 Ubisoft Entertainment
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Sharpmake;
+
+namespace HelloEvents
+{
+    public class CommonSolution : Sharpmake.Solution
+    {
+        public CommonSolution()
+            : base(typeof(CommonTarget))
+        {
+            IsFileNameToLower = false;
+        }
+
+        [ConfigurePriority(ConfigurePriorities.All)]
+        [Configure]
+        public virtual void ConfigureAll(Configuration conf, CommonTarget target)
+        {
+            conf.SolutionFileName = "[solution.Name]_[target.Platform]";
+            if (target.DevEnv != DevEnv.xcode4ios)
+                conf.SolutionFileName += "_[target.DevEnv]";
+            if (target.BuildSystem == BuildSystem.FastBuild)
+                conf.Name += "_FastBuild";
+            conf.PlatformName = "[target.SolutionPlatformName]";
+            conf.SolutionPath = System.IO.Path.Combine(Globals.TmpDirectory, "solutions");
+        }
+    }
+}

--- a/samples/HelloEvents/HelloEvents.CommonTarget.sharpmake.cs
+++ b/samples/HelloEvents/HelloEvents.CommonTarget.sharpmake.cs
@@ -1,0 +1,142 @@
+﻿// Copyright (c) 2021 Ubisoft Entertainment
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Sharpmake;
+
+namespace HelloEvents
+{
+    [Fragment, Flags]
+    public enum Optimization
+    {
+        Debug = 1 << 0,
+        Release = 1 << 1
+    }
+
+    [DebuggerDisplay("\"{Platform}_{DevEnv}\" {Name}")]
+    public class CommonTarget : Sharpmake.ITarget
+    {
+        public Platform Platform;
+        public DevEnv DevEnv;
+        public Optimization Optimization;
+        public Blob Blob;
+        public BuildSystem BuildSystem;
+
+        public CommonTarget() { }
+
+        public CommonTarget(
+            Platform platform,
+            DevEnv devEnv,
+            Optimization optimization,
+            Blob blob,
+            BuildSystem buildSystem
+        )
+        {
+            Platform = platform;
+            DevEnv = devEnv;
+            Optimization = optimization;
+            Blob = blob;
+            BuildSystem = buildSystem;
+        }
+
+        public override string Name
+        {
+            get
+            {
+                var nameParts = new List<string>
+                {
+                    Optimization.ToString()
+                };
+                return string.Join(" ", nameParts);
+            }
+        }
+
+        public string SolutionPlatformName
+        {
+            get
+            {
+                var nameParts = new List<string>();
+
+                nameParts.Add(Platform.ToString());
+
+                return string.Join("_", nameParts);
+            }
+        }
+
+        /// <summary>
+        /// returns a string usable as a directory name, to use for instance for the intermediate path
+        /// </summary>
+        public string DirectoryName
+        {
+            get
+            {
+                var dirNameParts = new List<string>();
+
+                dirNameParts.Add(Platform.ToString());
+                dirNameParts.Add(Optimization.ToString());
+
+                if (BuildSystem == BuildSystem.FastBuild)
+                    dirNameParts.Add(BuildSystem.ToString());
+
+                return string.Join("_", dirNameParts);
+            }
+        }
+
+        public override Sharpmake.Optimization GetOptimization()
+        {
+            switch (Optimization)
+            {
+                case Optimization.Debug:
+                    return Sharpmake.Optimization.Debug;
+                case Optimization.Release:
+                    return Sharpmake.Optimization.Release;
+                default:
+                    throw new NotSupportedException("Optimization value " + Optimization.ToString());
+            }
+        }
+
+        public override Platform GetPlatform()
+        {
+            return Platform;
+        }
+
+        public static CommonTarget[] GetDefaultTargets()
+        {
+            var result = new List<CommonTarget>();
+            result.AddRange(GetWin64Targets());
+            return result.ToArray();
+        }
+
+        public static CommonTarget[] GetWin64Targets()
+        {
+            var defaultTarget = new CommonTarget(
+                Platform.win64,
+                DevEnv.vs2019,
+                Optimization.Debug | Optimization.Release,
+                Blob.NoBlob,
+                BuildSystem.MSBuild
+            );
+
+            // make a fastbuild version of the target
+            var fastBuildTarget = (CommonTarget)defaultTarget.Clone(
+                Blob.FastBuildUnitys,
+                BuildSystem.FastBuild
+            );
+
+            return new[] { defaultTarget, fastBuildTarget };
+        }
+    }
+}

--- a/samples/HelloEvents/HelloEvents.Main.sharpmake.cs
+++ b/samples/HelloEvents/HelloEvents.Main.sharpmake.cs
@@ -1,0 +1,97 @@
+﻿// Copyright (c) 2021 Ubisoft Entertainment
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Sharpmake;
+using Sharpmake.Generators.FastBuild;
+
+[module: Sharpmake.DebugProjectName("Sharpmake.HelloEvents")]
+
+[module: Sharpmake.Include("HelloEvents.*.sharpmake.cs")]
+[module: Sharpmake.Include("codebase/*.sharpmake.cs")]
+[module: Sharpmake.Include("codebase/*/*.sharpmake.cs")]
+
+namespace HelloEvents
+{
+    public static class Globals
+    {
+        // branch root path relative to current sharpmake file location
+        public const string RelativeRootPath = @".\codebase";
+        public static string RootDirectory;
+        public static string TmpDirectory { get { return Path.Combine(RootDirectory, "temp"); } }
+        public static string OutputDirectory { get { return Path.Combine(TmpDirectory, "bin"); } }
+    }
+
+    public static class Main
+    {
+        private static void ConfigureRootDirectory()
+        {
+            FileInfo fileInfo = Util.GetCurrentSharpmakeFileInfo();
+            string rootDirectory = Path.Combine(fileInfo.DirectoryName, Globals.RelativeRootPath);
+            Globals.RootDirectory = Util.SimplifyPath(rootDirectory);
+        }
+
+        private static void ConfigureAutoCleanup()
+        {
+            Util.FilesAutoCleanupActive = true;
+            Util.FilesAutoCleanupDBPath = Path.Combine(Globals.TmpDirectory, "sharpmake");
+
+            if (!Directory.Exists(Util.FilesAutoCleanupDBPath))
+                Directory.CreateDirectory(Util.FilesAutoCleanupDBPath);
+        }
+
+        [Sharpmake.Main]
+        public static void SharpmakeMain(Sharpmake.Arguments arguments)
+        {
+            ConfigureRootDirectory();
+            ConfigureAutoCleanup();
+
+            FastBuildSettings.FastBuildWait = true;
+            FastBuildSettings.FastBuildSummary = false;
+            FastBuildSettings.FastBuildNoSummaryOnError = true;
+            FastBuildSettings.FastBuildDistribution = false;
+            FastBuildSettings.FastBuildMonitor = true;
+            FastBuildSettings.FastBuildAllowDBMigration = true;
+            FastBuildSettings.SetPathToResourceCompilerInEnvironment = true;
+
+            KitsRootPaths.SetKitsRoot10ToHighestInstalledVersion(DevEnv.vs2019);
+
+            // for the purpose of this sample, we'll reuse the FastBuild executables that live in the sharpmake source repo
+            string sharpmakeFastBuildDir = Util.PathGetAbsolute(Globals.RootDirectory, @"..\..\..\tools\FastBuild");
+            switch (Util.GetExecutingPlatform())
+            {
+                case Platform.linux:
+                    FastBuildSettings.FastBuildMakeCommand = Path.Combine(sharpmakeFastBuildDir, "Linux-x64", "fbuild");
+                    break;
+                case Platform.mac:
+                    FastBuildSettings.FastBuildMakeCommand = Path.Combine(sharpmakeFastBuildDir, "OSX-x64", "FBuild");
+                    break;
+                case Platform.win64:
+                default:
+                    FastBuildSettings.FastBuildMakeCommand = Path.Combine(sharpmakeFastBuildDir, "Windows-x64", "FBuild.exe");
+                    break;
+            }
+
+            Bff.UnityResolver = new Bff.FragmentUnityResolver();
+
+            foreach (Type solutionType in Assembly.GetExecutingAssembly().GetTypes().Where(t => !t.IsAbstract && t.IsSubclassOf(typeof(CommonSolution))))
+                arguments.Generate(solutionType);
+        }
+    }
+}

--- a/samples/HelloEvents/Properties/AssemblyInfo.cs
+++ b/samples/HelloEvents/Properties/AssemblyInfo.cs
@@ -1,0 +1,47 @@
+// Copyright (c) 2021 Ubisoft Entertainment
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("HelloEvents.Properties")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Ubisoft")]
+[assembly: AssemblyProduct("HelloEvents.Properties")]
+[assembly: AssemblyCopyright("Copyright \u00A9 Ubisoft 2021")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("CC6018D5-0760-463E-92FB-849E7E904449")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/samples/HelloEvents/codebase/HelloEvents.sharpmake.cs
+++ b/samples/HelloEvents/codebase/HelloEvents.sharpmake.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) 2021 Ubisoft Entertainment
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Sharpmake;
+
+namespace HelloEvents
+{
+    [Sharpmake.Generate]
+    public class HelloEventsSolution : CommonSolution
+    {
+        public HelloEventsSolution()
+        {
+            AddTargets(CommonTarget.GetDefaultTargets());
+            Name = "HelloEvents";
+        }
+
+        public override void ConfigureAll(Configuration conf, CommonTarget target)
+        {
+            base.ConfigureAll(conf, target);
+
+            conf.AddProject<ExeProject>(target);
+            conf.AddProject<Dll1Project>(target);
+            conf.AddProject<StaticLib1Project>(target);
+            conf.AddProject<StaticLib2Project>(target);
+        }
+    }
+}

--- a/samples/HelloEvents/codebase/dll1/dll1.sharpmake.cs
+++ b/samples/HelloEvents/codebase/dll1/dll1.sharpmake.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) 2021 Ubisoft Entertainment
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.IO;
+
+namespace HelloEvents
+{
+    [Sharpmake.Generate]
+    public class Dll1Project : CommonProject
+    {
+        public Dll1Project()
+        {
+            AddTargets(CommonTarget.GetDefaultTargets());
+            Name = "dll1";
+        }
+
+        public override void ConfigureAll(Configuration conf, CommonTarget target)
+        {
+            base.ConfigureAll(conf, target);
+
+            conf.SolutionFolder = "SharedLibs";
+
+            conf.PrecompHeader = "precomp.h";
+            conf.PrecompSource = "precomp.cpp";
+
+            conf.Output = Configuration.OutputType.Dll;
+
+            conf.Defines.Add("UTIL_DLL_EXPORT");
+            conf.ExportDefines.Add("UTIL_DLL_IMPORT");
+
+            conf.IncludePaths.Add(SourceRootPath);
+
+            conf.AddPrivateDependency<StaticLib1Project>(target);
+        }
+    }
+}

--- a/samples/HelloEvents/codebase/dll1/precomp.cpp
+++ b/samples/HelloEvents/codebase/dll1/precomp.cpp
@@ -1,0 +1,2 @@
+#include "precomp.h"
+

--- a/samples/HelloEvents/codebase/dll1/precomp.h
+++ b/samples/HelloEvents/codebase/dll1/precomp.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#pragma warning(push)
+#pragma warning(disable: 4710)
+#pragma warning(disable: 4711)
+#include <vector>
+#pragma warning(pop)

--- a/samples/HelloEvents/codebase/dll1/util_dll.cpp
+++ b/samples/HelloEvents/codebase/dll1/util_dll.cpp
@@ -1,0 +1,39 @@
+#include "precomp.h"
+#include "util_dll.h"
+
+#include "src/util_static_lib1.h"
+
+#pragma warning(push)
+#pragma warning(disable: 4668)
+#pragma warning(disable: 4710)
+#pragma warning(disable: 4711)
+#include <iostream>
+#pragma warning(pop)
+
+int UtilDll1::ComputeSum(const std::vector<int>& someInts)
+{
+    int acc = 0;
+    for (int item : someInts)
+        acc += item;
+
+#if defined(_DEBUG) && _DEBUG
+    std::cout << "- Dll1 is built in Debug"
+#  if defined(USES_FASTBUILD) && USES_FASTBUILD
+        " with FastBuild"
+#  endif
+        "!" << std::endl;
+#endif
+
+#if defined(NDEBUG) && NDEBUG
+    std::cout << "- Dll1 is built in Release"
+#  if defined(USES_FASTBUILD) && USES_FASTBUILD
+        " with FastBuild"
+#  endif
+        "!" << std::endl;
+#endif
+
+    acc += static_cast<int>(static_lib1_utils::GetRandomPosition());
+
+    return acc;
+}
+

--- a/samples/HelloEvents/codebase/dll1/util_dll.h
+++ b/samples/HelloEvents/codebase/dll1/util_dll.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#pragma warning(push)
+#pragma warning(disable: 4710)
+#pragma warning(disable: 4711)
+#include <vector>
+#pragma warning(pop)
+
+#if defined(UTIL_DLL_EXPORT) && defined(_MSC_VER)
+#   define UTIL_DLL __declspec(dllexport)
+#elif defined(UTIL_DLL_IMPORT) && defined(_MSC_VER)
+#   define UTIL_DLL __declspec(dllimport)
+#else
+#   define UTIL_DLL
+#endif
+
+struct UtilDll1
+{
+    UTIL_DLL int ComputeSum(const std::vector<int>& someInts);
+};
+

--- a/samples/HelloEvents/codebase/exe/exe.sharpmake.cs
+++ b/samples/HelloEvents/codebase/exe/exe.sharpmake.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) 2021 Ubisoft Entertainment
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Sharpmake;
+
+namespace HelloEvents
+{
+    [Sharpmake.Generate]
+    public class ExeProject : CommonProject
+    {
+        public ExeProject()
+        {
+            AddTargets(CommonTarget.GetDefaultTargets());
+            Name = "exe";
+        }
+
+        public override void ConfigureAll(Configuration conf, CommonTarget target)
+        {
+            base.ConfigureAll(conf, target);
+
+            conf.Output = Configuration.OutputType.Exe;
+
+            conf.PrecompHeader = "stdafx.h";
+            conf.PrecompSource = "stdafx.cpp";
+
+            conf.AddPrivateDependency<Dll1Project>(target);
+            conf.AddPrivateDependency<StaticLib2Project>(target);
+
+            conf.Defines.Add("CREATION_DATE=\"August 2021\"");
+        }
+    }
+}

--- a/samples/HelloEvents/codebase/exe/main.cpp
+++ b/samples/HelloEvents/codebase/exe/main.cpp
@@ -1,0 +1,37 @@
+#include "stdafx.h"
+#include "util_dll.h"
+#include "util_static_lib2.h"
+#include "sub folder/useless_static_lib2.h"
+
+int main(int, char**)
+{
+    std::cout << "Hello Events World, from " CREATION_DATE "!" << std::endl;
+
+#if defined(_DEBUG) && _DEBUG
+    std::cout << "- Exe is built in Debug"
+#  if defined(USES_FASTBUILD) && USES_FASTBUILD
+        " with FastBuild"
+#  endif
+        "!" << std::endl;
+#endif
+
+#if defined(NDEBUG) && NDEBUG
+    std::cout << "- Exe is built in Release"
+#  if defined(USES_FASTBUILD) && USES_FASTBUILD
+        " with FastBuild"
+#  endif
+        "!" << std::endl;
+#endif
+
+    std::vector<int> someArray(5, 6);
+
+    // from dll1
+    UtilDll1 utilityDll;
+    utilityDll.ComputeSum(someArray);
+
+    // from static_lib2
+    Util2 utilityStatic;
+    utilityStatic.DoSomethingUseful();
+    StaticLib2::UselessMethod();
+    return 0;
+}

--- a/samples/HelloEvents/codebase/exe/stdafx.cpp
+++ b/samples/HelloEvents/codebase/exe/stdafx.cpp
@@ -1,0 +1,1 @@
+#include "stdafx.h"

--- a/samples/HelloEvents/codebase/exe/stdafx.h
+++ b/samples/HelloEvents/codebase/exe/stdafx.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#pragma warning(push)
+#pragma warning(disable: 4668)
+#pragma warning(disable: 4710)
+#pragma warning(disable: 4711)
+#include <iostream>
+#pragma warning(pop)

--- a/samples/HelloEvents/codebase/static lib2/static_lib2.sharpmake.cs
+++ b/samples/HelloEvents/codebase/static lib2/static_lib2.sharpmake.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) 2021 Ubisoft Entertainment
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Sharpmake;
+
+namespace HelloEvents
+{
+    [Sharpmake.Generate]
+    public class StaticLib2Project : CommonProject
+    {
+        public StaticLib2Project()
+        {
+            AddTargets(CommonTarget.GetDefaultTargets());
+            Name = "static lib2";
+        }
+
+        public override void ConfigureAll(Configuration conf, CommonTarget target)
+        {
+            base.ConfigureAll(conf, target);
+
+            conf.SolutionFolder = "StaticLibs";
+
+            // skip the generation of the lib, and use the obj for the link instead
+            conf.Options.Add(Options.Vc.Linker.UseLibraryDependencyInputs.Enable);
+
+            conf.IncludePaths.Add(SourceRootPath);
+        }
+    }
+}

--- a/samples/HelloEvents/codebase/static lib2/sub folder/useless_static_lib2.cpp
+++ b/samples/HelloEvents/codebase/static lib2/sub folder/useless_static_lib2.cpp
@@ -1,0 +1,17 @@
+#include "useless_static_lib2.h"
+
+#pragma warning(push)
+#pragma warning(disable: 4668)
+#pragma warning(disable: 4710)
+#pragma warning(disable: 4711)
+#include <iostream>
+#pragma warning(pop)
+
+namespace StaticLib2
+{
+    void UselessMethod()
+    {
+        std::cout << "- Useless in fact!" << std::endl;
+    }
+}
+

--- a/samples/HelloEvents/codebase/static lib2/sub folder/useless_static_lib2.h
+++ b/samples/HelloEvents/codebase/static lib2/sub folder/useless_static_lib2.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace StaticLib2
+{
+    void UselessMethod();
+}
+

--- a/samples/HelloEvents/codebase/static lib2/util_static_lib2.cpp
+++ b/samples/HelloEvents/codebase/static lib2/util_static_lib2.cpp
@@ -1,0 +1,40 @@
+#include "util_static_lib2.h"
+
+#pragma warning(push)
+#pragma warning(disable: 4668)
+#pragma warning(disable: 4710)
+#pragma warning(disable: 4711)
+#include <iostream>
+#pragma warning(pop)
+
+Util2::Util2() = default;
+
+Util2::~Util2()
+{
+}
+
+void Util2::DoSomethingUseful() const
+{
+#if defined(_DEBUG) && _DEBUG
+    std::cout << "- StaticLib2 is built in Debug"
+#  if defined(USES_FASTBUILD) && USES_FASTBUILD
+        " with FastBuild"
+#  endif
+        "!" << std::endl;
+#endif
+
+#if defined(NDEBUG) && NDEBUG
+    std::cout << "- StaticLib2 is built in Release"
+#  if defined(USES_FASTBUILD) && USES_FASTBUILD
+        " with FastBuild"
+#  endif
+        "!" << std::endl;
+#endif
+
+    return DoSomethingInternal("Yeah right...");
+}
+
+void Util2::DoSomethingInternal(const char* anArgument) const
+{
+    std::cout << "Useful, right?\n- " << anArgument << std::endl;
+}

--- a/samples/HelloEvents/codebase/static lib2/util_static_lib2.h
+++ b/samples/HelloEvents/codebase/static lib2/util_static_lib2.h
@@ -1,0 +1,15 @@
+#pragma once
+
+class Util2
+{
+public:
+    Util2();
+    ~Util2();
+
+public:
+    void DoSomethingUseful() const;
+
+private:
+    void DoSomethingInternal(const char* anArgument) const;
+};
+

--- a/samples/HelloEvents/codebase/static_lib1/src/ensure_debug.cpp
+++ b/samples/HelloEvents/codebase/static_lib1/src/ensure_debug.cpp
@@ -1,0 +1,11 @@
+#include "src/pch.h"
+
+#if !_DEBUG
+    #error Expected Debug define (_DEBUG) was not found
+#endif
+
+#if defined(NDEBUG) && NDEBUG
+    #error Unexpected Release define (NDEBUG) was found
+#endif
+
+#pragma message("Debug is built!")

--- a/samples/HelloEvents/codebase/static_lib1/src/ensure_release.cpp
+++ b/samples/HelloEvents/codebase/static_lib1/src/ensure_release.cpp
@@ -1,0 +1,11 @@
+#include "src/pch.h"
+
+#if defined(_DEBUG) && _DEBUG
+    #error Unexpected Debug define (_DEBUG) was found
+#endif
+
+#if !NDEBUG
+    #error Expected Release define (NDEBUG) was not found
+#endif
+
+#pragma message("Release is built!")

--- a/samples/HelloEvents/codebase/static_lib1/src/pch.cpp
+++ b/samples/HelloEvents/codebase/static_lib1/src/pch.cpp
@@ -1,0 +1,2 @@
+#include "src/pch.h"
+

--- a/samples/HelloEvents/codebase/static_lib1/src/pch.h
+++ b/samples/HelloEvents/codebase/static_lib1/src/pch.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#pragma warning(push)
+#pragma warning(disable: 4668)
+#pragma warning(disable: 4710)
+#pragma warning(disable: 4711)
+#include <iostream>
+#pragma warning(pop)

--- a/samples/HelloEvents/codebase/static_lib1/src/util_static_lib1.cpp
+++ b/samples/HelloEvents/codebase/static_lib1/src/util_static_lib1.cpp
@@ -1,0 +1,28 @@
+#include "src/pch.h"
+#include "util_static_lib1.h"
+#include <ios>
+
+namespace static_lib1_utils
+{
+    std::streampos GetRandomPosition()
+    {
+#if defined(_DEBUG) && _DEBUG
+    std::cout << "- StaticLib1 is built in Debug"
+#  if defined(USES_FASTBUILD) && USES_FASTBUILD
+        " with FastBuild"
+#  endif
+        "!" << std::endl;
+#endif
+
+#if defined(NDEBUG) && NDEBUG
+    std::cout << "- StaticLib1 is built in Release"
+#  if defined(USES_FASTBUILD) && USES_FASTBUILD
+        " with FastBuild"
+#  endif
+        "!" << std::endl;
+#endif
+
+        return 1;
+    }
+}
+

--- a/samples/HelloEvents/codebase/static_lib1/src/util_static_lib1.h
+++ b/samples/HelloEvents/codebase/static_lib1/src/util_static_lib1.h
@@ -1,0 +1,7 @@
+#pragma once
+#include <iosfwd>
+
+namespace static_lib1_utils
+{
+    std::streampos GetRandomPosition();
+}

--- a/samples/HelloEvents/codebase/static_lib1/static_lib1.sharpmake.cs
+++ b/samples/HelloEvents/codebase/static_lib1/static_lib1.sharpmake.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) 2021 Ubisoft Entertainment
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Sharpmake;
+
+namespace HelloEvents
+{
+    [Sharpmake.Generate]
+    public class StaticLib1Project : CommonProject
+    {
+        public StaticLib1Project()
+        {
+            AddTargets(CommonTarget.GetDefaultTargets());
+            Name = "static_lib1";
+        }
+
+        public override void ConfigureAll(Configuration conf, CommonTarget target)
+        {
+            base.ConfigureAll(conf, target);
+
+            conf.SolutionFolder = "StaticLibs";
+
+            // intentionally in a subfolder
+            conf.PrecompHeader = @"src\pch.h";
+            conf.PrecompSource = @"src\pch.cpp";
+
+            conf.IncludePaths.Add(SourceRootPath);
+
+            switch (target.Optimization)
+            {
+                case Optimization.Debug:
+                    conf.SourceFilesBuildExclude.Add(@"src\ensure_release.cpp");
+                    break;
+                case Optimization.Release:
+                    // use a different method to exclude ensure_debug.cpp
+                    conf.SourceFilesBuildExcludeRegex.Add(Util.RegexPathCombine("src", @"ensure_d.*\.cpp$"));
+                    break;
+                default:
+                    throw new Error("Unexpected optimization " + target.Optimization);
+            }
+        }
+    }
+}

--- a/samples/Sharpmake.Samples.sharpmake.cs
+++ b/samples/Sharpmake.Samples.sharpmake.cs
@@ -188,6 +188,25 @@ namespace SharpmakeGen.Samples
     }
 
     [Generate]
+    public class HelloEventsProject : SampleProject
+    {
+        public HelloEventsProject()
+        {
+            Name = "HelloEvents";
+            SharpmakeMainFile = "HelloEvents.Main.sharpmake.cs";
+
+            // This one is special, we have .sharpmake.cs files in the codebase
+            SourceFilesExcludeRegex.Remove(@"\\codebase\\");
+        }
+
+        public override void ConfigureAll(Configuration conf, Target target)
+        {
+            base.ConfigureAll(conf, target);
+            conf.AddPrivateDependency<SharpmakeGeneratorsProject>(target);
+        }
+    }
+
+    [Generate]
     public class HelloLinuxProject : SampleProject
     {
         public HelloLinuxProject()


### PR DESCRIPTION
Try and figure out if the source of the postbuild copies is an output of one of the targets, and if so move the Copy node declaration after the node that defines it, and add it as a PreBuildDependency

- Add a new sample to test those kind of events, registered to github actions