### PR TITLE
Add /FS option to FastBuild example.

### DIFF
--- a/samples/FastBuildSimpleExecutable/FastBuildSimpleExecutable.sharpmake.cs
+++ b/samples/FastBuildSimpleExecutable/FastBuildSimpleExecutable.sharpmake.cs
@@ -57,6 +57,9 @@ namespace FastBuild
         {
             conf.IsFastBuild = true;
             conf.FastBuildBlobbed = target.Blob == Blob.FastBuildUnitys;
+
+            // Force writing to pdb from different cl.exe process to go through the pdb server
+            conf.AdditionalCompilerOptions.Add("/FS");
         }
     }
 


### PR DESCRIPTION
Missing this option causes cl.exe to fail when compiling multiple files at the same time.
Altough it's not needed for this simple file example, it serves as a guide for custom projects.

Personally, this would save me about 15 mins of researching :)