### PR TITLE
Add support for VcxprojUserFile.LocalDebuggerAttach

### DIFF
--- a/Sharpmake.Platforms/Sharpmake.CommonPlatforms/BasePlatform.Vcxproj.Template.cs
+++ b/Sharpmake.Platforms/Sharpmake.CommonPlatforms/BasePlatform.Vcxproj.Template.cs
@@ -170,6 +170,7 @@ namespace Sharpmake
     <LocalDebuggerCommandArguments>[conf.VcxprojUserFile.LocalDebuggerCommandArguments]</LocalDebuggerCommandArguments>
     <LocalDebuggerEnvironment>[conf.VcxprojUserFile.LocalDebuggerEnvironment]</LocalDebuggerEnvironment>
     <LocalDebuggerWorkingDirectory>[conf.VcxprojUserFile.LocalDebuggerWorkingDirectory]</LocalDebuggerWorkingDirectory>
+    <LocalDebuggerAttach>[conf.VcxprojUserFile.LocalDebuggerAttach]</LocalDebuggerAttach>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
 ";
 

--- a/Sharpmake.Platforms/Sharpmake.CommonPlatforms/BasePlatform.Vcxproj.Template.cs
+++ b/Sharpmake.Platforms/Sharpmake.CommonPlatforms/BasePlatform.Vcxproj.Template.cs
@@ -170,7 +170,7 @@ namespace Sharpmake
     <LocalDebuggerCommandArguments>[conf.VcxprojUserFile.LocalDebuggerCommandArguments]</LocalDebuggerCommandArguments>
     <LocalDebuggerEnvironment>[conf.VcxprojUserFile.LocalDebuggerEnvironment]</LocalDebuggerEnvironment>
     <LocalDebuggerWorkingDirectory>[conf.VcxprojUserFile.LocalDebuggerWorkingDirectory]</LocalDebuggerWorkingDirectory>
-    <LocalDebuggerAttach>[conf.VcxprojUserFile.LocalDebuggerAttach]</LocalDebuggerAttach>
+    <LocalDebuggerAttach>[conf.VcxprojUserFile.LocalDebuggerAttachString]</LocalDebuggerAttach>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
 ";
 

--- a/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Linux/LinuxPlatform.Vcxproj.Template.cs
+++ b/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Linux/LinuxPlatform.Vcxproj.Template.cs
@@ -86,7 +86,7 @@ namespace Sharpmake
                 @"    <LocalDebuggerCommand>[conf.VcxprojUserFile.LocalDebuggerCommand]</LocalDebuggerCommand>
         <LocalDebuggerCommandArguments>[conf.VcxprojUserFile.LocalDebuggerCommandArguments]</LocalDebuggerCommandArguments>
         <LocalDebuggerWorkingDirectory>[conf.VcxprojUserFile.LocalDebuggerWorkingDirectory]</LocalDebuggerWorkingDirectory>
-        <LocalDebuggerAttach>[conf.VcxprojUserFile.LocalDebuggerAttach]</LocalDebuggerAttach>
+        <LocalDebuggerAttach>[conf.VcxprojUserFile.LocalDebuggerAttachString]</LocalDebuggerAttach>
         <RemoteDebuggerCommand>[conf.VcxprojUserFile.RemoteDebuggerCommand]</RemoteDebuggerCommand>
         <RemoteDebuggerCommandArguments>[conf.VcxprojUserFile.RemoteDebuggerCommandArguments]</RemoteDebuggerCommandArguments>
         <RemoteDebuggingMode>[conf.VcxprojUserFile.RemoteDebuggingMode]</RemoteDebuggingMode>

--- a/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Linux/LinuxPlatform.Vcxproj.Template.cs
+++ b/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Linux/LinuxPlatform.Vcxproj.Template.cs
@@ -86,6 +86,7 @@ namespace Sharpmake
                 @"    <LocalDebuggerCommand>[conf.VcxprojUserFile.LocalDebuggerCommand]</LocalDebuggerCommand>
         <LocalDebuggerCommandArguments>[conf.VcxprojUserFile.LocalDebuggerCommandArguments]</LocalDebuggerCommandArguments>
         <LocalDebuggerWorkingDirectory>[conf.VcxprojUserFile.LocalDebuggerWorkingDirectory]</LocalDebuggerWorkingDirectory>
+        <LocalDebuggerAttach>[conf.VcxprojUserFile.LocalDebuggerAttach]</LocalDebuggerAttach>
         <RemoteDebuggerCommand>[conf.VcxprojUserFile.RemoteDebuggerCommand]</RemoteDebuggerCommand>
         <RemoteDebuggerCommandArguments>[conf.VcxprojUserFile.RemoteDebuggerCommandArguments]</RemoteDebuggerCommandArguments>
         <RemoteDebuggingMode>[conf.VcxprojUserFile.RemoteDebuggingMode]</RemoteDebuggingMode>

--- a/Sharpmake/Project.Configuration.cs
+++ b/Sharpmake/Project.Configuration.cs
@@ -2836,6 +2836,7 @@ namespace Sharpmake
                 public string LocalDebuggerCommandArguments = RemoveLineTag;
                 public string LocalDebuggerEnvironment = RemoveLineTag;
                 public string LocalDebuggerWorkingDirectory = RemoveLineTag;
+                public string LocalDebuggerAttach = RemoveLineTag;
                 public string RemoteDebuggerCommand = RemoveLineTag;
                 public string RemoteDebuggerCommandArguments = RemoveLineTag;
                 public string RemoteDebuggingMode = RemoveLineTag;

--- a/Sharpmake/Project.Configuration.cs
+++ b/Sharpmake/Project.Configuration.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021 Ubisoft Entertainment
+// Copyright (c) 2017-2021 Ubisoft Entertainmen
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -2836,12 +2836,13 @@ namespace Sharpmake
                 public string LocalDebuggerCommandArguments = RemoveLineTag;
                 public string LocalDebuggerEnvironment = RemoveLineTag;
                 public string LocalDebuggerWorkingDirectory = RemoveLineTag;
-                public string LocalDebuggerAttach = RemoveLineTag;
+                public bool LocalDebuggerAttach = false;
                 public string RemoteDebuggerCommand = RemoveLineTag;
                 public string RemoteDebuggerCommandArguments = RemoveLineTag;
                 public string RemoteDebuggingMode = RemoveLineTag;
                 public string RemoteDebuggerWorkingDirectory = RemoveLineTag;
-                public bool OverwriteExistingFile = true;
+                public bool OverwriteExistingFile = true; 
+                public string LocalDebuggerAttachString => LocalDebuggerAttach ? "true" : RemoveLineTag;
             }
 
             public VcxprojUserFileSettings VcxprojUserFile = null;

--- a/Sharpmake/Project.Configuration.cs
+++ b/Sharpmake/Project.Configuration.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021 Ubisoft Entertainmen
+// Copyright (c) 2017-2021 Ubisoft Entertainment
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
In my project I hot reload DLL plugins, and for this reason I want to attach my debugger to a running executable instead of launching it.

The regression tests succeeded, I don't know if I have to provide anything else.
Thank you!