### PR TITLE
[Android] Fixes required to get android projects working correctly

### DIFF
--- a/Sharpmake.Generators/VisualStudio/Androidproj.Template.cs
+++ b/Sharpmake.Generators/VisualStudio/Androidproj.Template.cs
@@ -139,6 +139,14 @@ namespace Sharpmake.Generators.VisualStudio
 @"    <ClInclude Include=""[file.FileNameProjectRelative]"" />
 ";
 
+                public const string ProjectFilesSource =
+@"    <JavaCompile Include=""[file.FileNameProjectRelative]"" />
+";
+
+                public const string ProjectFilesContent =
+@"    <Content Include=""[file.FileNameProjectRelative]"" />
+";
+
                 public static string ContentSimple =
 @"    <Content Include=""[file.FileNameSourceRelative]"" />
 ";

--- a/Sharpmake.Generators/VisualStudio/IPlatformVcxproj.cs
+++ b/Sharpmake.Generators/VisualStudio/IPlatformVcxproj.cs
@@ -46,7 +46,6 @@ namespace Sharpmake.Generators.VisualStudio
         string SharedLibraryFileFullExtension { get; }
         string ProgramDatabaseFileFullExtension { get; }
         string StaticLibraryFileFullExtension { get; }
-        string StaticOutputLibraryFileFullExtension { get; }
 
         bool ExcludesPrecompiledHeadersFromBuild { get; }
         bool HasUserAccountControlSupport { get; }

--- a/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Android/AndroidPlatform.Vcxproj.Template.cs
+++ b/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Android/AndroidPlatform.Vcxproj.Template.cs
@@ -17,8 +17,11 @@ namespace Sharpmake
     {
         public sealed partial class AndroidPlatform
         {
+            private const string _projectStartPlatformConditionalPart =
+    @"'$(Platform)'=='[platform]'";
+
             private const string _projectStartPlatformConditional =
-    @"  <PropertyGroup Label=""Globals"" Condition=""'$(Platform)'=='ARM64' Or '$(Platform)'=='x64' Or '$(Platform)'=='ARM' Or '$(Platform)'=='x86'"">
+    @"  <PropertyGroup Label=""Globals"" Condition=""[condition]"">
 ";
 
             private const string _projectDescriptionPlatformSpecific =

--- a/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Android/AndroidPlatform.cs
+++ b/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Android/AndroidPlatform.cs
@@ -65,8 +65,20 @@ namespace Sharpmake
             #region Project.Configuration.IConfigurationTasks implementation
             public void SetupDynamicLibraryPaths(Project.Configuration configuration, DependencySetting dependencySetting, Project.Configuration dependency)
             {
-                // Not tested. We may need to root the path like we do in SetupStaticLibraryPaths.
-                DefaultPlatform.SetupLibraryPaths(configuration, dependencySetting, dependency);
+                if (!dependency.Project.GetType().IsDefined(typeof(Export), false))
+                {
+                    if (dependencySetting.HasFlag(DependencySetting.LibraryPaths))
+                        configuration.AddDependencyBuiltTargetLibraryPath(dependency.TargetLibraryPath, dependency.TargetLibraryPathOrderNumber);
+                }
+                else
+                {
+                    if (dependencySetting.HasFlag(DependencySetting.LibraryPaths))
+                        configuration.DependenciesOtherLibraryPaths.Add(dependency.TargetLibraryPath, dependency.TargetLibraryPathOrderNumber);
+                }
+
+                // Refernce library using -l<name>, build system knows to look for lib<name>.so
+                if (dependencySetting.HasFlag(DependencySetting.LibraryFiles))
+                    configuration.AdditionalLinkerOptions.Add("-l" + dependency.TargetFileName);
             }
 
             public void SetupStaticLibraryPaths(Project.Configuration configuration, DependencySetting dependencySetting, Project.Configuration dependency)

--- a/Sharpmake.Platforms/Sharpmake.CommonPlatforms/BasePlatform.cs
+++ b/Sharpmake.Platforms/Sharpmake.CommonPlatforms/BasePlatform.cs
@@ -135,7 +135,6 @@ namespace Sharpmake
         public abstract string SharedLibraryFileFullExtension { get; }
         public abstract string ProgramDatabaseFileFullExtension { get; }
         public virtual string StaticLibraryFileFullExtension => ".lib";
-        public virtual string StaticOutputLibraryFileFullExtension => StaticLibraryFileFullExtension;
         public virtual bool ExcludesPrecompiledHeadersFromBuild => false;
         public virtual bool HasUserAccountControlSupport => false;
         public virtual bool HasEditAndContinueDebuggingSupport => false;

--- a/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Linux/LinuxPlatform.cs
+++ b/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Linux/LinuxPlatform.cs
@@ -111,7 +111,6 @@ namespace Sharpmake
             public override string ProgramDatabaseFileFullExtension => string.Empty;
             public override string StaticLibraryFileFullExtension => ".a";
             public override string SharedLibraryFileFullExtension => ".so";
-            public override string StaticOutputLibraryFileFullExtension => string.Empty;
             public override string ExecutableFileFullExtension => string.Empty;
 
             // Ideally the object files should be suffixed .o when compiling with FastBuild, using the CompilerOutputExtension property in ObjectLists

--- a/Sharpmake/Project.cs
+++ b/Sharpmake/Project.cs
@@ -2684,6 +2684,8 @@ namespace Sharpmake
 
         public AndroidPackageProject(Type targetType) : base(targetType)
         {
+            SourceFilesExtensions = new Strings(".java", ".xml");
+            SourceFilesCompileExtensions = new Strings(".java");
         }
     }
 }

--- a/Sharpmake/Sharpmake.csproj
+++ b/Sharpmake/Sharpmake.csproj
@@ -174,7 +174,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net472'">
     <PackageReference Include="Basic.Reference.Assemblies.Net472" Version="1.2.4" />
-    <PackageReference Include="System.Text.Json" Version="5.0.2" />
+    <PackageReference Include="System.Text.Json" Version="6.0.2" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" />

--- a/Sharpmake/Sharpmake.sharpmake.cs
+++ b/Sharpmake/Sharpmake.sharpmake.cs
@@ -30,7 +30,7 @@ namespace SharpmakeGen
             if (target.Framework.IsDotNetFramework())
             {
                 conf.ReferencesByNuGetPackage.Add("Basic.Reference.Assemblies.Net472", "1.2.4");
-                conf.ReferencesByNuGetPackage.Add("System.Text.Json", "5.0.2");
+                conf.ReferencesByNuGetPackage.Add("System.Text.Json", "6.0.2");
             }
             else if (target.Framework.IsDotNetCore())
             {


### PR DESCRIPTION
The first commit allows android arm/arm64 and pc win32/win64 builds to live in the same project if you are not using android x86/x64. I do this so I can share a manually curated filters file.

The second commit has a bunch of things I needed to get the projects compiling and deploying properly. It's mostly a rollup of the changes in #100.