### PR TITLE
[Cross Platform] Add cross platform support to compile script

### DIFF
--- a/CompileSharpmake.bat
+++ b/CompileSharpmake.bat
@@ -1,8 +1,10 @@
 @echo off
 :: Batch arguments:
-:: %~1: Project/Solution to build
-:: %~2: Target(Normally should be Debug or Release)
-:: %~3: Platform(Normally should be "Any CPU" for sln and AnyCPU for a csproj)
+:: %~1: Project/Solution to build (default: Sharpmake.sln)
+:: %~2: Target(Normally should be Debug or Release) (default: Debug)
+:: %~3: Platform(Normally should be "AnyCPU") (default: AnyCPU)
+:: Using a specific platform identifier, i.e. win-x64, linux-x64, ios-x64, will publish a single file executable for that platform
+:: %~4: Framework - When using a platform specifier other than AnyCPU, you need to also specify the target framework
 :: if none are passed, defaults to building Sharpmake.sln in Debug|AnyCPU
 
 setlocal enabledelayedexpansion
@@ -29,21 +31,35 @@ echo MSBuild batch path: !VSMSBUILDCMD!
 call !VSMSBUILDCMD!
 if %errorlevel% NEQ 0 goto error
 
-if "%~1" == "" (
-    call :BuildSharpmakeDotnet "%~dp0Sharpmake.sln" "Debug" "Any CPU"
-) else (
-    call :BuildSharpmakeDotnet %1 %2 %3
+set PROJSLN_FILE="%~dp0Sharpmake.sln"
+if not "%~1" == "" (
+    set PROJSLN_FILE=%1
 )
+
+set TARGET="Debug"
+if not "%~2" == "" (
+    set TARGET=%2
+)
+
+set PLATFORM="AnyCPU"
+set FRAMEWORK=""
+if not "%~3" == "" (
+    if not "%~3" == "AnyCPU" (
+        if "%~3" == "" (
+            echo ERROR: When specifying a specific platform "%~3" you must also give a target framework (i.e. net5.0)
+        )
+        set PLATFORM=%3
+        set FRAMEWORK=%4
+    )
+)
+
+call :BuildSharpmakeDotnet %PROJSLN_FILE% %TARGET% %PLATFORM% %FRAMEWORK%
 
 if %errorlevel% EQU 0 goto success
 
 echo Compilation with dotnet failed, falling back to the old way using MSBuild
 
-if "%~1" == "" (
-    call :BuildSharpmakeMSBuild "%~dp0Sharpmake.sln" "Debug" "Any CPU"
-) else (
-    call :BuildSharpmakeMSBuild %1 %2 %3
-)
+call :BuildSharpmakeMSBuild %PROJSLN_FILE% %TARGET% %PLATFORM%
 
 if %errorlevel% NEQ 0 goto error
 
@@ -55,6 +71,10 @@ goto success
 echo Compiling %~1 in "%~2|%~3"...
 
 set DOTNET_BUILD_CMD=dotnet build "%~1" -nologo -v m -c "%~2"
+if not "%~3" == "AnyCPU" (
+    :: If target a specific platform use full platform build command
+    set DOTNET_BUILD_CMD=dotnet publish "%~1" -nologo -v m -c "%~2" -r %~3 -f %~4
+)
 echo %DOTNET_BUILD_CMD%
 %DOTNET_BUILD_CMD%
 set ERROR_CODE=%errorlevel%

--- a/Sharpmake.Application/Sharpmake.Application.csproj
+++ b/Sharpmake.Application/Sharpmake.Application.csproj
@@ -18,6 +18,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <Deterministic>true</Deterministic>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoWarn>1570,1591</NoWarn>
     <InvariantGlobalization>true</InvariantGlobalization>
     <MSBuildProjectExtensionsPath>..\tmp\projects\Sharpmake.Application</MSBuildProjectExtensionsPath>
   </PropertyGroup>

--- a/Sharpmake.Generators/Sharpmake.Generators.csproj
+++ b/Sharpmake.Generators/Sharpmake.Generators.csproj
@@ -15,6 +15,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <Deterministic>true</Deterministic>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoWarn>1570,1591</NoWarn>
     <InvariantGlobalization>true</InvariantGlobalization>
     <MSBuildProjectExtensionsPath>..\tmp\projects\Sharpmake.Generators</MSBuildProjectExtensionsPath>
   </PropertyGroup>
@@ -31,7 +33,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>618</WarningsNotAsErrors>
     <Prefer32Bit>false</Prefer32Bit>
-    <NoWarn>1570,1591</NoWarn>
     <LangVersion>7</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)|$(TargetFramework)'=='Debug|AnyCPU|net5.0'">
@@ -47,7 +48,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>618</WarningsNotAsErrors>
     <Prefer32Bit>false</Prefer32Bit>
-    <NoWarn>1570,1591</NoWarn>
     <LangVersion>7</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)|$(TargetFramework)'=='Release|AnyCPU|net472'">
@@ -63,7 +63,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>618</WarningsNotAsErrors>
     <Prefer32Bit>false</Prefer32Bit>
-    <NoWarn>1570,1591</NoWarn>
     <LangVersion>7</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)|$(TargetFramework)'=='Release|AnyCPU|net5.0'">
@@ -79,7 +78,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>618</WarningsNotAsErrors>
     <Prefer32Bit>false</Prefer32Bit>
-    <NoWarn>1570,1591</NoWarn>
     <LangVersion>7</LangVersion>
   </PropertyGroup>
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />

--- a/Sharpmake.Main.sharpmake.cs
+++ b/Sharpmake.Main.sharpmake.cs
@@ -61,6 +61,15 @@ namespace SharpmakeGen
 
                 CustomProperties.Add("Deterministic", "true");
 
+                // PathUtil.cs uses some unsafe blocks
+                CustomProperties.Add("AllowUnsafeBlocks", "true");
+
+                // Adding doc warning suppression here to apply to all configs so it will
+                // take effect when publishing for other platforms not specified in the default configurations
+                // W1: CS1570: XML comment on 'construct' has badly formed XML - 'reason
+                // W4: CS1591: Missing XML comment for publicly visible type or member 'Type_or_Member'
+                CustomProperties.Add("NoWarn", "1570,1591");
+
                 // Enable Globalization Invariant Mode
                 // https://github.com/dotnet/runtime/blob/master/docs/design/features/globalization-invariant-mode.md
                 CustomProperties.Add("InvariantGlobalization", "true");
@@ -103,16 +112,6 @@ namespace SharpmakeGen
                         618 // W1: CS0618: A class member was marked with the Obsolete attribute, such that a warning will be issued when the class member is referenced
                     )
                 );
-
-                if (GenerateDocumentationFile)
-                {
-                    conf.Options.Add(
-                        new Options.CSharp.SuppressWarning(
-                            1570, // W1: CS1570: XML comment on 'construct' has badly formed XML - 'reason
-                            1591  // W4: CS1591: Missing XML comment for publicly visible type or member 'Type_or_Member'
-                        )
-                    );
-                }
             }
         }
     }

--- a/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Sharpmake.CommonPlatforms.csproj
+++ b/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Sharpmake.CommonPlatforms.csproj
@@ -15,6 +15,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <Deterministic>true</Deterministic>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoWarn>1570,1591</NoWarn>
     <InvariantGlobalization>true</InvariantGlobalization>
     <MSBuildProjectExtensionsPath>..\..\tmp\projects\Sharpmake.CommonPlatforms</MSBuildProjectExtensionsPath>
   </PropertyGroup>
@@ -31,7 +33,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>618</WarningsNotAsErrors>
     <Prefer32Bit>false</Prefer32Bit>
-    <NoWarn>1570,1591</NoWarn>
     <LangVersion>7</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)|$(TargetFramework)'=='Debug|AnyCPU|net5.0'">
@@ -47,7 +48,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>618</WarningsNotAsErrors>
     <Prefer32Bit>false</Prefer32Bit>
-    <NoWarn>1570,1591</NoWarn>
     <LangVersion>7</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)|$(TargetFramework)'=='Release|AnyCPU|net472'">
@@ -63,7 +63,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>618</WarningsNotAsErrors>
     <Prefer32Bit>false</Prefer32Bit>
-    <NoWarn>1570,1591</NoWarn>
     <LangVersion>7</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)|$(TargetFramework)'=='Release|AnyCPU|net5.0'">
@@ -79,7 +78,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>618</WarningsNotAsErrors>
     <Prefer32Bit>false</Prefer32Bit>
-    <NoWarn>1570,1591</NoWarn>
     <LangVersion>7</LangVersion>
   </PropertyGroup>
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />

--- a/Sharpmake/Sharpmake.csproj
+++ b/Sharpmake/Sharpmake.csproj
@@ -15,6 +15,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <Deterministic>true</Deterministic>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoWarn>1570,1591</NoWarn>
     <InvariantGlobalization>true</InvariantGlobalization>
     <RestoreAdditionalProjectSources>https://api.nuget.org/v3/index.json</RestoreAdditionalProjectSources>
     <MSBuildProjectExtensionsPath>..\tmp\projects\Sharpmake</MSBuildProjectExtensionsPath>
@@ -33,7 +35,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>618</WarningsNotAsErrors>
     <Prefer32Bit>false</Prefer32Bit>
-    <NoWarn>1570,1591</NoWarn>
     <LangVersion>7</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)|$(TargetFramework)'=='Debug|AnyCPU|net5.0'">
@@ -50,7 +51,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>618</WarningsNotAsErrors>
     <Prefer32Bit>false</Prefer32Bit>
-    <NoWarn>1570,1591</NoWarn>
     <LangVersion>7</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)|$(TargetFramework)'=='Release|AnyCPU|net472'">
@@ -67,7 +67,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>618</WarningsNotAsErrors>
     <Prefer32Bit>false</Prefer32Bit>
-    <NoWarn>1570,1591</NoWarn>
     <LangVersion>7</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)|$(TargetFramework)'=='Release|AnyCPU|net5.0'">
@@ -84,7 +83,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>618</WarningsNotAsErrors>
     <Prefer32Bit>false</Prefer32Bit>
-    <NoWarn>1570,1591</NoWarn>
     <LangVersion>7</LangVersion>
   </PropertyGroup>
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />


### PR DESCRIPTION
I use this to build for all platforms from my windows machine.

I used to use ``/p:PublishSingleFile=true`` to reduce the number of dependent dlls generated, however recent changes means that you can't reference module filenames when in that mode which breaks a lot of sharpmake code. It would be great to support that feature eventually so the linux/max executables are only a few files instead of ~200.