### PR TITLE
[Mac] Roundup of fixes for building on mac

### DIFF
--- a/Sharpmake.Generators/GeneratorManager.cs
+++ b/Sharpmake.Generators/GeneratorManager.cs
@@ -129,45 +129,44 @@ namespace Sharpmake.Generators
                              List<string> generatedFiles,
                              List<string> skipFiles)
         {
-            if (configurations[0].Platform == Platform.ios || configurations[0].Platform == Platform.mac)
+            DevEnv devEnv = configurations[0].Target.GetFragment<DevEnv>();
+            switch (devEnv)
             {
-                XCWorkspaceGenerator.Generate(builder, solution, configurations, solutionFile, generatedFiles, skipFiles);
-                if (UtilityMethods.HasFastBuildConfig(configurations))
-                {
-                    MasterBffGenerator.Generate(builder, solution, configurations, solutionFile, generatedFiles, skipFiles);
-                }
-            }
-            else
-            {
-                DevEnv devEnv = configurations[0].Target.GetFragment<DevEnv>();
-                switch (devEnv)
-                {
-                    case DevEnv.make:
+                case DevEnv.make:
+                    {
+                        if (configurations[0].Platform == Platform.android)
+                            MakeApplicationGenerator.Generate(builder, solution, configurations, solutionFile, generatedFiles, skipFiles);
+                        else
+                            MakefileGenerator.Generate(builder, solution, configurations, solutionFile, generatedFiles, skipFiles);
+                        break;
+                    }
+                case DevEnv.vs2015:
+                case DevEnv.vs2017:
+                case DevEnv.vs2019:
+                case DevEnv.vs2022:
+                    {
+                        if (UtilityMethods.HasFastBuildConfig(configurations))
                         {
-                            if (configurations[0].Platform == Platform.android)
-                                MakeApplicationGenerator.Generate(builder, solution, configurations, solutionFile, generatedFiles, skipFiles);
-                            else
-                                MakefileGenerator.Generate(builder, solution, configurations, solutionFile, generatedFiles, skipFiles);
-                            break;
+                            MasterBffGenerator.Generate(builder, solution, configurations, solutionFile, generatedFiles, skipFiles);
                         }
-                    case DevEnv.vs2015:
-                    case DevEnv.vs2017:
-                    case DevEnv.vs2019:
-                    case DevEnv.vs2022:
-                        {
-                            if (UtilityMethods.HasFastBuildConfig(configurations))
-                            {
-                                MasterBffGenerator.Generate(builder, solution, configurations, solutionFile, generatedFiles, skipFiles);
-                            }
 
-                            SlnGenerator.Generate(builder, solution, configurations, solutionFile, generatedFiles, skipFiles);
-                            break;
-                        }
-                    default:
+                        SlnGenerator.Generate(builder, solution, configurations, solutionFile, generatedFiles, skipFiles);
+                        break;
+                    }
+                case DevEnv.xcode4ios:
+                    {
+                        if (UtilityMethods.HasFastBuildConfig(configurations))
                         {
-                            throw new Error("Generate called with unknown DevEnv: " + devEnv);
+                            MasterBffGenerator.Generate(builder, solution, configurations, solutionFile, generatedFiles, skipFiles);
                         }
-                }
+
+                        XCWorkspaceGenerator.Generate(builder, solution, configurations, solutionFile, generatedFiles, skipFiles);
+                        break;
+                    }
+                default:
+                    {
+                        throw new Error("Generate called with unknown DevEnv: " + devEnv);
+                    }
             }
         }
     }

--- a/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Apple/BaseApplePlatform.cs
+++ b/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Apple/BaseApplePlatform.cs
@@ -619,6 +619,7 @@ namespace Sharpmake
             );
 
             context.SelectOption(
+                Options.Option(Options.XCode.Compiler.LibraryStandard.CompilerDefault, () => { options["LibraryStandard"] = FileGeneratorUtilities.RemoveLineTag; cmdLineOptions["LibraryStandard"] = FileGeneratorUtilities.RemoveLineTag; }),
                 Options.Option(Options.XCode.Compiler.LibraryStandard.CppStandard, () => { options["LibraryStandard"] = "libstdc++"; cmdLineOptions["LibraryStandard"] = "-stdlib=libstdc++"; }),
                 Options.Option(Options.XCode.Compiler.LibraryStandard.LibCxx, () => { options["LibraryStandard"] = "libc++"; cmdLineOptions["LibraryStandard"] = "-stdlib=libc++"; })
             );
@@ -645,6 +646,7 @@ namespace Sharpmake
             );
 
             context.SelectOption(
+                Options.Option(Options.XCode.Compiler.LibraryStandard.CompilerDefault, () => { options["LibraryStandard"] = FileGeneratorUtilities.RemoveLineTag; }),
                 Options.Option(Options.XCode.Compiler.LibraryStandard.CppStandard, () => options["LibraryStandard"] = "libstdc++"),
                 Options.Option(Options.XCode.Compiler.LibraryStandard.LibCxx, () => options["LibraryStandard"] = "libc++")
             );

--- a/Sharpmake/ExtensionMethods.cs
+++ b/Sharpmake/ExtensionMethods.cs
@@ -25,6 +25,10 @@ namespace Sharpmake
         {
             return platform == Platform.win32 || platform == Platform.win64;
         }
+        public static bool IsMac(this Platform platform)
+        {
+            return platform == Platform.ios || platform == Platform.mac;
+        }
 
         public static bool IsMicrosoft(this Platform platform)
         {

--- a/Sharpmake/Options.XCode.cs
+++ b/Sharpmake/Options.XCode.cs
@@ -263,8 +263,9 @@ namespace Sharpmake
 
                 public enum LibraryStandard
                 {
-                    CppStandard,
                     [Default]
+                    CompilerDefault,
+                    CppStandard,
                     LibCxx
                 }
 


### PR DESCRIPTION
Two of these changes are to get makefiles working properly on mac, the third was just nice since then I didn't have to specify which standard library to use (which might have changed between xcode versions).

For the linker one, it turns out -l isn't super portable, but ld is fully capable of taking in objects, archive and dynamic object  (so,dynlib) by path directly without using -l.