### PR TITLE
fix typo in PackageReferences.AssetsDependency 'ContentFile'

### DIFF
--- a/Sharpmake.UnitTests/PackageReferencesTest.cs
+++ b/Sharpmake.UnitTests/PackageReferencesTest.cs
@@ -25,6 +25,17 @@ namespace Sharpmake.UnitTests
         }
 
         [Test]
+        public void PackageReferencesAssetsDependency()
+        {
+            foreach (PackageReferences.AssetsDependency dep in System.Enum.GetValues(typeof(PackageReferences.AssetsDependency)))
+            {
+                var formatted = PackageReferences.PackageReference.GetFormatedAssetsDependency(dep);
+                Assert.AreEqual(1, formatted.Count());
+                Assert.AreEqual(formatted.First().ToLower(), dep.ToString().ToLower());
+            }
+        }
+
+        [Test]
         public void PackageReferencesAdded()
         {
             var project = GetProject<PackageReferencesTestProjects.PublicAndPrivatePackageReferencesProject>();

--- a/Sharpmake/PackageReferences.cs
+++ b/Sharpmake/PackageReferences.cs
@@ -158,14 +158,14 @@ namespace Sharpmake
             None = 0,
             Compile = 1 << 0,
             Runtime = 1 << 1,
-            ContentFile = 1 << 2,
+            ContentFiles = 1 << 2,
             Build = 1 << 3,
             Analysers = 1 << 4,
             Native = 1 << 5,
-            All = Compile | Runtime | ContentFile | Build | Analysers | Native
+            All = Compile | Runtime | ContentFiles | Build | Analysers | Native
         }
 
         internal const AssetsDependency DefaultPrivateAssets =
-            AssetsDependency.ContentFile | AssetsDependency.Analysers | AssetsDependency.Build;
+            AssetsDependency.ContentFiles | AssetsDependency.Analysers | AssetsDependency.Build;
     }
 }

--- a/Sharpmake/PackageReferences.cs
+++ b/Sharpmake/PackageReferences.cs
@@ -158,7 +158,7 @@ namespace Sharpmake
             None = 0,
             Compile = 1 << 0,
             Runtime = 1 << 1,
-            [Obsolete("Use 'ContentFiles' insead")]
+            [Obsolete("Use 'ContentFiles' instead")]
             ContentFile = 1 << 2,
             Build = 1 << 3,
             Analysers = 1 << 4,

--- a/Sharpmake/PackageReferences.cs
+++ b/Sharpmake/PackageReferences.cs
@@ -176,7 +176,7 @@ namespace Sharpmake
             None = 0,
             Compile = 1 << 0,
             Runtime = 1 << 1,
-            [Obsolete("Use ContentFiles instead")]
+            [Obsolete("Use " + nameof(ContentFiles) + " instead")]
             ContentFile = 1 << 2,
             ContentFiles = 1 << 2,
             Build = 1 << 3,

--- a/Sharpmake/PackageReferences.cs
+++ b/Sharpmake/PackageReferences.cs
@@ -99,16 +99,34 @@ namespace Sharpmake
                     yield break;
                 }
 
-                foreach (var value in (AssetsDependency[])Enum.GetValues(typeof(AssetsDependency)))
+                if (dependency.HasFlag(AssetsDependency.Compile))
                 {
-                    if (!dependency.HasFlag(value) || value == AssetsDependency.All || value == AssetsDependency.None)
-                    {
-                        continue;
-                    }
+                    yield return "compile";
+                }
 
-                    var name = Enum.GetName(typeof(AssetsDependency), value);
-                    // The first letter of assets values are in lower case (example: 'contentFiles')
-                    yield return $"{char.ToLower(name[0])}{name.Substring(1)}";
+                if (dependency.HasFlag(AssetsDependency.Runtime))
+                {
+                    yield return "runtime";
+                }
+
+                if (dependency.HasFlag(AssetsDependency.ContentFiles))
+                {
+                    yield return "contentFiles";
+                }
+
+                if (dependency.HasFlag(AssetsDependency.Build))
+                {
+                    yield return "build";
+                }
+
+                if (dependency.HasFlag(AssetsDependency.Analysers))
+                {
+                    yield return "analyzers";
+                }
+
+                if (dependency.HasFlag(AssetsDependency.Native))
+                {
+                    yield return "native";
                 }
             }
         }
@@ -158,12 +176,12 @@ namespace Sharpmake
             None = 0,
             Compile = 1 << 0,
             Runtime = 1 << 1,
-            [Obsolete("Use 'ContentFiles' instead")]
+            [Obsolete("Use ContentFiles instead")]
             ContentFile = 1 << 2,
+            ContentFiles = 1 << 2,
             Build = 1 << 3,
             Analysers = 1 << 4,
             Native = 1 << 5,
-            ContentFiles = 1 << 6,
             All = Compile | Runtime | ContentFiles | Build | Analysers | Native
         }
 

--- a/Sharpmake/PackageReferences.cs
+++ b/Sharpmake/PackageReferences.cs
@@ -158,10 +158,12 @@ namespace Sharpmake
             None = 0,
             Compile = 1 << 0,
             Runtime = 1 << 1,
-            ContentFiles = 1 << 2,
+            [Obsolete]
+            ContentFile = 1 << 2,
             Build = 1 << 3,
             Analysers = 1 << 4,
             Native = 1 << 5,
+            ContentFiles = 1 << 6,
             All = Compile | Runtime | ContentFiles | Build | Analysers | Native
         }
 

--- a/Sharpmake/PackageReferences.cs
+++ b/Sharpmake/PackageReferences.cs
@@ -158,7 +158,7 @@ namespace Sharpmake
             None = 0,
             Compile = 1 << 0,
             Runtime = 1 << 1,
-            [Obsolete]
+            [Obsolete("Use 'ContentFiles' insead")]
             ContentFile = 1 << 2,
             Build = 1 << 3,
             Analysers = 1 << 4,

--- a/Sharpmake/PackageReferences.cs
+++ b/Sharpmake/PackageReferences.cs
@@ -119,7 +119,7 @@ namespace Sharpmake
                     yield return "build";
                 }
 
-                if (dependency.HasFlag(AssetsDependency.Analysers))
+                if (dependency.HasFlag(AssetsDependency.Analyzers))
                 {
                     yield return "analyzers";
                 }
@@ -180,12 +180,14 @@ namespace Sharpmake
             ContentFile = 1 << 2,
             ContentFiles = 1 << 2,
             Build = 1 << 3,
+            [Obsolete("Use " + nameof(Analyzers) + " instead")]
             Analysers = 1 << 4,
+            Analyzers = 1 << 4,
             Native = 1 << 5,
-            All = Compile | Runtime | ContentFiles | Build | Analysers | Native
+            All = Compile | Runtime | ContentFiles | Build | Analyzers | Native
         }
 
         internal const AssetsDependency DefaultPrivateAssets =
-            AssetsDependency.ContentFiles | AssetsDependency.Analysers | AssetsDependency.Build;
+            AssetsDependency.ContentFiles | AssetsDependency.Analyzers | AssetsDependency.Build;
     }
 }


### PR DESCRIPTION
'ContentFile' => 'ContentFiles'

The enum value is used to serialize while serializing the project template, but the spelling of the enumeration is defined as 'contentFiles' here: https://docs.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files

Also: are there any plans for support of **IncludeAssets** and **ExcludeAssets**? 

And, what about the newer **buildMultitargeting** and **buildTransitive** enum values?

Best,
Fabian