### PR TITLE
Add support for the 'nullable' property in C# projects

### DIFF
--- a/Sharpmake.Generators/VisualStudio/Csproj.Template.cs
+++ b/Sharpmake.Generators/VisualStudio/Csproj.Template.cs
@@ -113,6 +113,7 @@ namespace Sharpmake.Generators.VisualStudio
     <ProductVersion>[options.ProductVersion]</ProductVersion>
     <UseWpf>[options.UseWpf]</UseWpf>
     <UseWindowsForms>[options.UseWindowsForms]</UseWindowsForms>
+    <Nullable>[options.Nullable]</Nullable>
   </PropertyGroup>
 ";
 

--- a/Sharpmake.Generators/VisualStudio/Csproj.cs
+++ b/Sharpmake.Generators/VisualStudio/Csproj.cs
@@ -3473,6 +3473,12 @@ namespace Sharpmake.Generators.VisualStudio
                 Options.Option(Options.CSharp.UseWindowsForms.Disabled, () => { options["UseWindowsForms"] = RemoveLineTag; })
             );
 
+            SelectOption
+            (
+                Options.Option(Options.CSharp.Nullable.Enabled, () => { options["Nullable"] = "enable"; }),
+                Options.Option(Options.CSharp.Nullable.Disabled, () => { options["Nullable"] = RemoveLineTag; })
+            );
+
             // concat defines, don't add options.Defines since they are automatically added by VS
             Strings defines = new Strings();
             defines.AddRange(options.ExplicitDefines);

--- a/Sharpmake/Options.CSharp.cs
+++ b/Sharpmake/Options.CSharp.cs
@@ -195,6 +195,13 @@ namespace Sharpmake
                 Disabled
             }
 
+            public enum Nullable
+            {
+                [Default] 
+                Disabled,
+                Enabled
+            }
+
             public class UpdateInterval : IntOption
             {
                 public UpdateInterval(int interval)


### PR DESCRIPTION
Add support for the 'nullable' property in C# projects
See https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/tutorials/nullable-reference-types