### PR TITLE
Fix the auto-detection for the resource compiler (rc.exe) when using FastBuild

### DIFF
--- a/Sharpmake.Generators/FastBuild/MasterBff.cs
+++ b/Sharpmake.Generators/FastBuild/MasterBff.cs
@@ -613,7 +613,7 @@ namespace Sharpmake.Generators.FastBuild
                 //       4) If not, add a PATH environment variable pointing to the rc.exe folder
 
                 List<Platform> microsoftPlatforms = PlatformRegistry.GetAvailablePlatforms<IMicrosoftPlatformBff>().ToList();
-                var resourceCompilerPaths = new Strings();
+                var resourceCompilerPaths = string.Empty;
                 foreach (CompilerSettings setting in masterBffInfo.CompilerSettings.Values)
                 {
                     if (!microsoftPlatforms.Any(x => setting.PlatformFlags.HasFlag(x)))
@@ -630,21 +630,15 @@ namespace Sharpmake.Generators.FastBuild
                             // if so, try to find a rc.exe near it
                             if (!File.Exists(Path.Combine(configuration.LinkerPath, "rc.exe")))
                             {
-                                // if not found, get the folder of the custom
-                                // rc.exe or the default one to add it to PATH
-                                if (configuration.ResourceCompiler != FileGeneratorUtilities.RemoveLineTag)
-                                    resourceCompilerPaths.Add(Path.GetDirectoryName(configuration.ResourceCompiler));
-                                else
-                                    resourceCompilerPaths.Add(defaultResourceCompilerPath);
+                                // if not found, get the folder of the default one to add it to PATH
+                                resourceCompilerPaths = defaultResourceCompilerPath;
                             }
                         }
                     }
                 }
 
-                if (resourceCompilerPaths.Count == 1)
-                    fastBuildPATH = Util.GetCapitalizedPath(resourceCompilerPaths.First());
-                else if (resourceCompilerPaths.Count > 1)
-                    throw new Error("Multiple conflicting resource compilers found in PATH! Please verify your ResourceCompiler settings.");
+                if ( resourceCompilerPaths != string.Empty )
+                    fastBuildPATH = Util.GetCapitalizedPath(resourceCompilerPaths);
             }
 
             var allDevEnv = masterBffInfo.CompilerSettings.Values.Select(s => s.DevEnv).Distinct().ToList();

--- a/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Windows/Win64Platform.cs
+++ b/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Windows/Win64Platform.cs
@@ -103,6 +103,18 @@ namespace Sharpmake
                     }
                 }
 
+                var resCompilerName = "ResourceCompiler";
+                if ( !masterCompilerSettings.ContainsKey( resCompilerName ) )
+                {  
+                    string resCompiler = devEnv.GetWindowsResourceCompiler(Platform.win64);
+                    string pathName;
+                    string rcName;
+                    Util.PathSplitFileNameFromPath( resCompiler, out rcName, out pathName );
+                    rcName = @"$ExecutableRootPath$\" + rcName;
+                    var resourceCompilerSettings = new CompilerSettings( resCompilerName, Sharpmake.CompilerFamily.Custom, Platform.win64, new Strings(), rcName, pathName, devEnv, new Dictionary<string, CompilerSettings.Configuration>() );
+                    masterCompilerSettings.Add( resCompilerName, resourceCompilerSettings );
+                }
+
                 if (platformToolset != Options.Vc.General.PlatformToolset.Default && !platformToolset.IsDefaultToolsetForDevEnv(devEnv))
                     compilerName += "-" + platformToolset;
                 else
@@ -310,10 +322,6 @@ namespace Sharpmake
                 else if (!fastBuildCompilerSettings.LibrarianExe.TryGetValue(devEnv, out librarianExe))
                     librarianExe = "lib.exe";
 
-                string resCompiler;
-                if (!fastBuildCompilerSettings.ResCompiler.TryGetValue(devEnv, out resCompiler))
-                    resCompiler = devEnv.GetWindowsResourceCompiler(Platform.win64);
-
                 string capitalizedBinPath = Util.GetCapitalizedPath(Util.PathGetAbsolute(projectRootPath, binPath));
                 configurations.Add(
                     configName,
@@ -321,7 +329,7 @@ namespace Sharpmake
                         Platform.win64,
                         binPath: capitalizedBinPath,
                         linkerPath: Util.GetCapitalizedPath(Util.PathGetAbsolute(projectRootPath, linkerPath)),
-                        resourceCompiler: Util.GetCapitalizedPath(Util.PathGetAbsolute(projectRootPath, resCompiler)),
+                        resourceCompiler: "ResourceCompiler",
                         librarian: Path.Combine(@"$LinkerPath$", librarianExe),
                         linker: Path.Combine(@"$LinkerPath$", linkerExe)
                     )


### PR DESCRIPTION
The auto-detection for the rc.exe (needed for MFC resources) fails for FastBuild
This adds a separate Compiler ("ResourceCompiler") definition where we can add 'CompilerFamily: custom' to avoid auto-detection