### PR TITLE
Add the Platforms element to avoid VS complaining in C# projects

### DIFF
--- a/Sharpmake.Generators/VisualStudio/Csproj.Template.cs
+++ b/Sharpmake.Generators/VisualStudio/Csproj.Template.cs
@@ -39,6 +39,7 @@ namespace Sharpmake.Generators.VisualStudio
 @"  <PropertyGroup>
     <Configuration Condition="" '$(Configuration)' == '' "">[options.DefaultConfiguration]</Configuration>
     <Platform Condition="" '$(Platform)' == '' "">[defaultPlatform]</Platform>
+    <Platforms>[defaultPlatform]</Platforms>
     <PlatformTarget Condition="" '$(Platform)' == '' "">[defaultPlatform]</PlatformTarget>
     <ProjectGuid>{[guid]}</ProjectGuid>
     <OutputType>[outputType]</OutputType>


### PR DESCRIPTION
Platforms element is now written to the project file with default platform.

Technically we should write all platforms there, but for our purposes we always have one platform (x64) so this is enough for now.
Without that element VS complains about the solution being wrong for the projects