### PR TITLE
Added proper support for .Net Core/.Net 5.0 C++/CLI project support

### DIFF
--- a/Sharpmake.Generators/VisualStudio/Vcxproj.Template.cs
+++ b/Sharpmake.Generators/VisualStudio/Vcxproj.Template.cs
@@ -42,7 +42,8 @@ namespace Sharpmake.Generators.VisualStudio
                 public static string ProjectDescription =
 @"  <PropertyGroup Label=""Globals"">
     <ProjectGuid>{[guid]}</ProjectGuid>
-    <TargetFrameworkVersion>[targetFramework]</TargetFrameworkVersion>
+    <TargetFrameworkVersion>[targetFrameworkVersion]</TargetFrameworkVersion>
+    <TargetFramework>[targetFramework]</TargetFramework>
     <Keyword>[projectKeyword]</Keyword>
     <DefaultLanguage>en-US</DefaultLanguage>
     <RootNamespace>[projectName]</RootNamespace>

--- a/Sharpmake.Generators/VisualStudio/Vcxproj.cs
+++ b/Sharpmake.Generators/VisualStudio/Vcxproj.cs
@@ -599,15 +599,17 @@ namespace Sharpmake.Generators.VisualStudio
 
                     if (!conf.IsFastBuild)
                     {
-
                         var compileAsManagedString = FileGeneratorUtilities.RemoveLineTag;
 
-                        var dotNetFramework = conf.Target.GetFragment<DotNetFramework>();
-                        
-                        if (clrSupport && !dotNetFramework.IsDotNetCore())
+                        if ( clrSupport )
                         {
-                            // This needs to be omitted when targeting .Net Core otherwise compilation fails due to internal compiler errors. Only info found is from here: https://stackoverflow.com/a/62773057
-                            compileAsManagedString = "true";
+                            var dotNetFramework = conf.Target.GetFragment<DotNetFramework>();
+                        
+                            if( !dotNetFramework.IsDotNetCore())
+                            {
+                                // This needs to be omitted when targeting .Net Core otherwise compilation fails due to internal compiler errors. Only info found is from here: https://stackoverflow.com/a/62773057
+                                compileAsManagedString = "true";
+                            }
                         }
 
                         using (fileGenerator.Declare("platformName", Util.GetPlatformString(conf.Platform, conf.Project, conf.Target)))

--- a/Sharpmake.Platforms/Sharpmake.CommonPlatforms/BasePlatform.Vcxproj.Template.cs
+++ b/Sharpmake.Platforms/Sharpmake.CommonPlatforms/BasePlatform.Vcxproj.Template.cs
@@ -28,7 +28,7 @@ namespace Sharpmake
       <AdditionalIncludeDirectories>[options.AdditionalIncludeDirectories]</AdditionalIncludeDirectories>
       <AdditionalUsingDirectories>[options.AdditionalUsingDirectories]</AdditionalUsingDirectories>
       <DebugInformationFormat>[options.DebugInformationFormat]</DebugInformationFormat>
-      <CompileAsManaged>[clrSupport]</CompileAsManaged>
+      <CompileAsManaged>[compileAsManaged]</CompileAsManaged>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <TreatWarningAsError>[options.TreatWarningAsError]</TreatWarningAsError>
       <DiagnosticsFormat>[options.DiagnosticsFormat]</DiagnosticsFormat>


### PR DESCRIPTION
Added proper support for .Net Core (and .Net 5.0) C++/CLI-projects as per instructions here
https://docs.microsoft.com/en-us/dotnet/core/porting/cpp-cli (works for .Net 5.0) as well.

Note that CompileAsManaged-element had to be removed when compiling for .Net Core (or .Net 5.0) otherwise things fail due to Internal Compiler error.