### PR TITLE
Fix CustomFileBuildStep not working with static libraries under FastBuild

### DIFF
--- a/Sharpmake.FunctionalTests/FastBuildFunctionalTest/FastBuildFunctionalTest.sharpmake.cs
+++ b/Sharpmake.FunctionalTests/FastBuildFunctionalTest/FastBuildFunctionalTest.sharpmake.cs
@@ -147,11 +147,14 @@ namespace SharpmakeGen.FunctionalTests
 
     public abstract class CommonProject : Project
     {
+        private string CustomFileBuildStepExtension { get; }  = ".customfilebuildstep";
+
         public CommonProject()
             : base(typeof(Target))
         {
             RootPath = @"[project.SharpmakeCsPath]";
             SourceRootPath = @"[project.RootPath]\codebase\[project.Name]";
+            SourceFilesExtensions.Add(CustomFileBuildStepExtension);
 
             AddTargets(Target.GetDefaultTargets());
         }
@@ -197,6 +200,34 @@ namespace SharpmakeGen.FunctionalTests
         [Configure(Platform.win64)]
         public virtual void ConfigureWin64(Configuration conf, Target target)
         {
+        }
+
+        public override void PostResolve()
+        {
+            base.PostResolve();
+
+            foreach (var config in Configurations)
+            {
+                var outputDir = Path.Combine(config.IntermediatePath, "generated");
+                config.IncludePrivatePaths.Add(outputDir);
+
+                foreach (var sourcePath in ResolvedSourceFiles.Where(file => file.EndsWith(CustomFileBuildStepExtension)))
+                {
+                    var fileName = Path.GetFileName(sourcePath);
+                    var outputPath = Path.Combine(outputDir, fileName.Replace(CustomFileBuildStepExtension, ""));
+
+                    var buildStep = new Configuration.CustomFileBuildStep
+                    {
+                        KeyInput = sourcePath,
+                        Output = outputPath,
+                        Description = $"Build {Name}_{config.Name}_{fileName}",
+                        Executable = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "cmd.exe"),
+                        ExecutableArguments = "/c copy \"[input]\" \"[output]\""
+                    };
+
+                    config.CustomFileBuildSteps.Add(buildStep);
+                }
+            }
         }
     }
 
@@ -554,10 +585,30 @@ namespace SharpmakeGen.FunctionalTests
     }
 
     [Generate]
-    public class SimpleLib : CommonProject
+    public class SimpleStaticLib : CommonProject
     {
-        public SimpleLib()
+        public SimpleStaticLib()
         {
+        }
+
+        public override void ConfigureAll(Configuration conf, Target target)
+        {
+            base.ConfigureAll(conf, target);
+            conf.Output = Configuration.OutputType.Lib;
+        }
+    }
+
+    [Generate]
+    public class SimpleDynamicLib : CommonProject
+    {
+        public SimpleDynamicLib()
+        {
+        }
+
+        public override void ConfigureAll(Configuration conf, Target target)
+        {
+            base.ConfigureAll(conf, target);
+            conf.Output = Configuration.OutputType.Dll;
         }
     }
 
@@ -570,7 +621,8 @@ namespace SharpmakeGen.FunctionalTests
         public override void ConfigureAll(Configuration conf, Target target)
         {
             base.ConfigureAll(conf, target);
-            conf.AddPublicDependency<SimpleLib>(target);
+            conf.AddPublicDependency<SimpleStaticLib>(target);
+            conf.AddPublicDependency<SimpleDynamicLib>(target);
         }
     }
 

--- a/Sharpmake.FunctionalTests/FastBuildFunctionalTest/codebase/SimpleDynamicLib/simpledynamiclib.cpp
+++ b/Sharpmake.FunctionalTests/FastBuildFunctionalTest/codebase/SimpleDynamicLib/simpledynamiclib.cpp
@@ -1,0 +1,5 @@
+#include "simpledynamiclib.h"
+
+void ExportFunction()
+{
+}

--- a/Sharpmake.FunctionalTests/FastBuildFunctionalTest/codebase/SimpleDynamicLib/simpledynamiclib.h.customfilebuildstep
+++ b/Sharpmake.FunctionalTests/FastBuildFunctionalTest/codebase/SimpleDynamicLib/simpledynamiclib.h.customfilebuildstep
@@ -1,0 +1,5 @@
+#pragma once
+
+// We must export a symbol in order for LIB file to
+// be created along DLL as we need to link it to EXE.
+__declspec(dllexport) void ExportFunction();

--- a/Sharpmake.FunctionalTests/FastBuildFunctionalTest/codebase/SimpleExeWithLib/main.cpp
+++ b/Sharpmake.FunctionalTests/FastBuildFunctionalTest/codebase/SimpleExeWithLib/main.cpp
@@ -1,3 +1,5 @@
+#include "simpleexewithlib.h"
+
 int main(int, char**)
 {
     return 0;

--- a/Sharpmake.FunctionalTests/FastBuildFunctionalTest/codebase/SimpleExeWithLib/simpleexewithlib.h.customfilebuildstep
+++ b/Sharpmake.FunctionalTests/FastBuildFunctionalTest/codebase/SimpleExeWithLib/simpleexewithlib.h.customfilebuildstep
@@ -1,0 +1,1 @@
+#pragma once

--- a/Sharpmake.FunctionalTests/FastBuildFunctionalTest/codebase/SimpleStaticLib/simplestaticlib.cpp
+++ b/Sharpmake.FunctionalTests/FastBuildFunctionalTest/codebase/SimpleStaticLib/simplestaticlib.cpp
@@ -1,0 +1,1 @@
+#include "simplestaticlib.h"

--- a/Sharpmake.FunctionalTests/FastBuildFunctionalTest/codebase/SimpleStaticLib/simplestaticlib.h.customfilebuildstep
+++ b/Sharpmake.FunctionalTests/FastBuildFunctionalTest/codebase/SimpleStaticLib/simplestaticlib.h.customfilebuildstep
@@ -1,0 +1,1 @@
+#pragma once

--- a/Sharpmake.Generators/FastBuild/Bff.cs
+++ b/Sharpmake.Generators/FastBuild/Bff.cs
@@ -1007,6 +1007,7 @@ namespace Sharpmake.Generators.FastBuild
                         var orderedForceUsingDeps = UtilityMethods.GetOrderedFlattenedProjectDependencies(conf, false, true);
                         fastBuildPreBuildDependencies.AddRange(orderedForceUsingDeps.Select(dep => GetShortProjectName(dep.Project, dep)));
                         fastBuildPreBuildDependencies.AddRange(preBuildTargets);
+                        fastBuildPreBuildDependencies.AddRange(fileCustomBuildKeys);
 
                         if (projectHasResourceFiles)
                             resourceFilesSections.Add(fastBuildOutputFileShortName + "_resources");


### PR DESCRIPTION
> CustomFileBuildStep targets were not being added to .PreBuildDependencies of Library() in BFF, only to Executable() and DLL(). Issue was only affecting FastBuild and not MSBuild. Added functional test cases for FastBuild that check if CustomFileBuildStep is working for all three types of projects.

We initially built our project using Sharpmake with MSBuild and this was one of the first issues that we encountered when we started transitioning to FastBuild.

Modifications to functional tests currently rely on Windows/MSVC because:
- Windows command prompt is invoked to call `copy` command to imitate simple CustomFileBuildStep
- Function is exported using `__declspec(dllexport)` attribute to make sure LIB file is created with DLL

It seems that functional tests are only run on Windows (at least in CI), so please let me know if functional tests need to be able to run on other platforms.

I am not 100% sure if `PostResolve` is the best place to have logic for adding CustomFileBuildStep. I didn't use `ConfigureAll` because we need populated `ResolvedSourceFiles` here. Please advise if there is a better way. :)

Thanks!