### PR TITLE
Do not sort list of compiler extra files in master Bff

### DIFF
--- a/Sharpmake.Generators/FastBuild/Bff.Util.cs
+++ b/Sharpmake.Generators/FastBuild/Bff.Util.cs
@@ -671,12 +671,13 @@ namespace Sharpmake.Generators.FastBuild
             }
         }
 
-        internal static string FBuildCollectionFormat(Strings collection, int spaceLength, Strings includedExtensions = null)
+        internal static string FBuildCollectionFormat(Strings collection, int spaceLength, Strings includedExtensions = null, bool sort = true)
         {
             // Select items.
+            List<string> collectionItems = sort ? collection.SortedValues : collection.Values;
             List<string> items = new List<string>(collection.Count);
 
-            foreach (string collectionItem in collection.SortedValues)
+            foreach (string collectionItem in collectionItems)
             {
                 if (includedExtensions == null)
                 {

--- a/Sharpmake.Generators/FastBuild/MasterBff.cs
+++ b/Sharpmake.Generators/FastBuild/MasterBff.cs
@@ -735,7 +735,7 @@ namespace Sharpmake.Generators.FastBuild
                 using (masterBffGenerator.Declare("fastbuildCompilerName", compiler.Key))
                 using (masterBffGenerator.Declare("fastBuildCompilerRootPath", compilerSettings.RootPath))
                 using (masterBffGenerator.Declare("fastBuildCompilerExecutable", string.IsNullOrEmpty(compilerSettings.Executable) ? FileGeneratorUtilities.RemoveLineTag : compilerSettings.Executable))
-                using (masterBffGenerator.Declare("fastBuildExtraFiles", compilerSettings.ExtraFiles.Count > 0 ? UtilityMethods.FBuildCollectionFormat(compilerSettings.ExtraFiles, 28) : FileGeneratorUtilities.RemoveLineTag))
+                using (masterBffGenerator.Declare("fastBuildExtraFiles", compilerSettings.ExtraFiles.Count > 0 ? UtilityMethods.FBuildCollectionFormat(compilerSettings.ExtraFiles, 28, sort: false) : FileGeneratorUtilities.RemoveLineTag))
                 using (masterBffGenerator.Declare("fastBuildCompilerFamily", string.IsNullOrEmpty(fastBuildCompilerFamily) ? FileGeneratorUtilities.RemoveLineTag : fastBuildCompilerFamily))
                 using (masterBffGenerator.Declare("fastBuildCompilerUseRelativePaths", fastBuildCompilerUseRelativePaths))
                 using (masterBffGenerator.Declare("fastBuildCompilerAdditionalSettings", fastBuildCompilerAdditionalSettings))


### PR DESCRIPTION
FastBuild calculates toolchain manifest hash key based on binary contents of compiler files, where paths of these files are not being factored it - it should not matter whether absolute or relative paths are used. However, order of these files listed in BFF changes the resulting hash key, which will invalidate or break compatibility with existing FastBuild cache. This can happen unpredictably with vendoring when some build tools stored in version control could end up before/after other files in the list that are installed in the system. Extra files for compiler are already being added in deterministic order, so there should be no need to sort them in BFF.

Example of described problem: Sorting ``"C:\Program Files (x86)\Windows Kits\10\Redist\"`` against ``"C:\a_workspace_repo\vendor\MSVC"`` and ``"C:\z_workspace_repo\vendor\MSVC"`` directories gives two different orders that produces different tool manifest hash keys. In this case it should not matter where workspace with vendored build tools is located - with relative paths developer should be able to choose where to place them and still remain compatible with existing cache.