### PR TITLE
Allow /help option handling from sources/assemblies

### DIFF
--- a/Sharpmake.Application/CommandLineArguments.cs
+++ b/Sharpmake.Application/CommandLineArguments.cs
@@ -71,6 +71,7 @@ namespace Sharpmake.Application
             public bool GenerateDebugSolutionOnly = false;
             public string DebugSolutionStartArguments = string.Empty;
             public string DebugSolutionPath = string.Empty;
+            public bool PrintHelp = false;
 
             [CommandLine.Option("sources", @"sharpmake sources files: ex: /sources( ""project1.sharpmake"", ""..\..\project2.sharpmake"" )")]
             public void SetSources(params string[] files)

--- a/Sharpmake/Builder.cs
+++ b/Sharpmake/Builder.cs
@@ -34,6 +34,8 @@ namespace Sharpmake
 
         public FileInfo MainFileInfo = null;
 
+        public bool PrintHelp { get; }
+
         public void AddFragmentMask(params object[] fragmentMasks)
         {
             foreach (object fragmentMask in fragmentMasks)
@@ -73,9 +75,10 @@ namespace Sharpmake
             TypesToGenerate.Add(type);
         }
 
-        public Arguments(Builder builder)
+        public Arguments(Builder builder, bool printHelp)
         {
             Builder = builder;
+            PrintHelp = printHelp;
         }
     }
 
@@ -264,11 +267,12 @@ namespace Sharpmake
             bool skipInvalidPath,
             bool diagnostics,
             bool debugScripts,
+            bool printHelp,
             Func<IGeneratorManager> getGeneratorsManagerCallBack,
             HashSet<string> defines)
         {
             Context = context;
-            Arguments = new Arguments(this);
+            Arguments = new Arguments(this, printHelp);
             _multithreaded = multithreaded;
             DumpDependencyGraph = dumpDependencyGraph;
             _cleanBlobsOnly = cleanBlobsOnly;
@@ -297,8 +301,8 @@ namespace Sharpmake
         }
 
         [Obsolete("Use the builder with the new debugScripts argument", error: false)]
-        public Builder(BuildContext.BaseBuildContext context, bool multithreaded, bool dumpDependencyGraph, bool cleanBlobsOnly, bool blobOnly, bool skipInvalidPath, bool diagnostics, Func<IGeneratorManager> getGeneratorsManagerCallBack, HashSet<string> defines)
-            : this(context, multithreaded, dumpDependencyGraph, cleanBlobsOnly, blobOnly, skipInvalidPath, diagnostics, true, getGeneratorsManagerCallBack, defines) { }
+        public Builder(BuildContext.BaseBuildContext context, bool multithreaded, bool dumpDependencyGraph, bool cleanBlobsOnly, bool blobOnly, bool skipInvalidPath, bool diagnostics, bool printHelp, Func<IGeneratorManager> getGeneratorsManagerCallBack, HashSet<string> defines)
+            : this(context, multithreaded, dumpDependencyGraph, cleanBlobsOnly, blobOnly, skipInvalidPath, diagnostics, true, printHelp, getGeneratorsManagerCallBack, defines) { }
 
         public void Dispose()
         {

--- a/Sharpmake/CommandLine.cs
+++ b/Sharpmake/CommandLine.cs
@@ -123,7 +123,7 @@ namespace Sharpmake
             return false;
         }
 
-        public static string GetCommandLineHelp(Type type, bool staticMethod)
+        public static string GetCommandLineHelp(Type type, bool staticMethod, bool printPreamble = false)
         {
             StringWriter help = new StringWriter();
 
@@ -132,11 +132,20 @@ namespace Sharpmake
             List<string> sortedMethodNames = new List<string>(methodMappings.Keys);
             sortedMethodNames.Sort();
 
-            help.WriteLine("Usage: sharpmake [options]");
-            help.WriteLine("Options:");
+            if (printPreamble)
+            {
+                help.WriteLine("Usage: sharpmake [options]");
+                help.WriteLine("Options:");
+            }
 
+            bool firstCommandLine = true;
             foreach (string commandLine in sortedMethodNames)
             {
+                if (!firstCommandLine)
+                {
+                    help.WriteLine("");
+                }
+
                 help.Write("  /" + commandLine);
 
                 foreach (MethodInfo methodInfo in methodMappings[commandLine])
@@ -161,7 +170,7 @@ namespace Sharpmake
                     }
                 }
 
-                help.WriteLine("");
+                firstCommandLine = false;
             }
 
             return help.ToString();


### PR DESCRIPTION
> Change allows handling /help command line option in loaded sources/assemblies (by e.g. calling Sharpmake.CommandLine.GetCommandLineHelp) instead of terminating immediately after only printing help for built-in Sharpmake commands. Doing so will require sources/assemblies to check for Arguments.PrintHelp in Main function and return before generating any targets (otherwise exception will be raised).

So basically this change allows Sharpmake to be called in the following way:
`> Sharpmake.Application.exe /sources(@'Main.cs') /help`

Which instead of terminating after printing built-in Sharpmake command line help, will load sources/assemblies and run Main function with Arguments.PrintHelp to allow user code to print additional help like this:
```
public static void SharpmakeMain(Arguments arguments)
{
    var settings = new Settings();
    CommandLine.ExecuteOnObject(settings);

    if(arguments.PrintHelp)
    {
        Console.WriteLine(CommandLine.GetCommandLineHelp(typeof(Settings), false));
        return; // Don't generate any tagets if we are expected to only print help.
    }

    arguments.Generate<Solution>();
}
```

Example output:
```
sharpmake 0.20.2
  arguments: /sources(@'Main.cs') /help
  directory: C:\some\directory
  platform: win64 - Microsoft Windows 10.0.19044
  compiled with framework: .NETCoreApp,Version=v5.0
  running on framework: .NET 5.0.17

Usage: sharpmake [options]
Options:
  /DumpDependency()
        Dump projects dependencies in dot format: ex: /DumpDependency

  /assemblies(params String[] files)

  /blobonly()
        Only generate blob and work blob files: ex: /blobonly

  /* ... */

  /verbose()
        Writes time and action information during progress: ex:/verbose

  /writefiles(value)
        Sets if the generated files should be written or not. Default value: true. ex: /writefiles(<true|false>)

  /HelloWorldFromMainCS()
        Example option from source/assembly
```

Feedback is welcome for different/alternative ways of accomplishing this.