### PR TITLE
Add missing CppLanguageStandard.CPP20 for NMake Intellisense helper.

### DIFF
--- a/Sharpmake.Generators/VisualStudio/ProjectOptionsGenerator.cs
+++ b/Sharpmake.Generators/VisualStudio/ProjectOptionsGenerator.cs
@@ -386,6 +386,7 @@ namespace Sharpmake.Generators.VisualStudio
                 Options.Option(Options.Vc.Compiler.CppLanguageStandard.CPP11, () => { }),
                 Options.Option(Options.Vc.Compiler.CppLanguageStandard.CPP14, () => { cppLanguageStd = "/std:c++14"; }),
                 Options.Option(Options.Vc.Compiler.CppLanguageStandard.CPP17, () => { cppLanguageStd = "/std:c++17"; }),
+                Options.Option(Options.Vc.Compiler.CppLanguageStandard.CPP20, () => { cppLanguageStd = "/std:c++20"; }),
                 Options.Option(Options.Vc.Compiler.CppLanguageStandard.GNU98, () => { }),
                 Options.Option(Options.Vc.Compiler.CppLanguageStandard.GNU11, () => { }),
                 Options.Option(Options.Vc.Compiler.CppLanguageStandard.GNU14, () => { cppLanguageStd = "/std:c++14"; }),


### PR DESCRIPTION
This patch adds a missing CPP20 option to the list of converted settings.
Without it, whenever a project uses specifically CPP20 standard,
it is not properly translated into NMake project, therefore
Intellisense (and similar software) doesn't pick it up correctly.