### PR TITLE
Add option to force project references export

### DIFF
--- a/Sharpmake.Generators/VisualStudio/Vcxproj.cs
+++ b/Sharpmake.Generators/VisualStudio/Vcxproj.cs
@@ -1081,7 +1081,7 @@ namespace Sharpmake.Generators.VisualStudio
 
             if (context.Builder.Diagnostics
                 && context.Project.AllowInconsistentDependencies == false
-                && context.ProjectConfigurations.Any(c => ConfigurationNeedReferences(c)))
+                && (context.ProjectConfigurations.Any(c => ConfigurationNeedReferences(c)) || context.Project.ForceReferencesExport))
             {
                 CheckReferenceDependenciesConsistency(context);
             }
@@ -1090,7 +1090,7 @@ namespace Sharpmake.Generators.VisualStudio
                 ? context.ProjectConfigurations.Any(c => ConfigurationNeedReferences(c))
                 : ConfigurationNeedReferences(firstConf);
 
-            if (addDependencies)
+            if (addDependencies || context.Project.ForceReferencesExport)
             {
                 var dependencies = new UniqueList<ProjectDependencyInfo>();
                 foreach (var configuration in context.ProjectConfigurations)

--- a/Sharpmake/Project.cs
+++ b/Sharpmake/Project.cs
@@ -262,6 +262,15 @@ namespace Sharpmake
         // Setting this to true will force dependencies regardless of different output types.
         public bool AllowInconsistentDependencies = false;
 
+        /// <summary>
+        /// Forces project references to be exported regardless of different output types.
+        /// </summary>
+        /// <remarks>
+        /// Sharpmake does not export project references for output types when it is unnecessary.
+        /// If you wish to export them, anyway, set this boolean to <c>true</c>.
+        /// </remarks>
+        public bool ForceReferencesExport = false;
+
         private string _blobPath = "[project.SourceRootPath]" + Path.DirectorySeparatorChar + "blob";
         public string BlobPath
         {


### PR DESCRIPTION
Similarly to #219, I am working on sharing the precompiled header between multiple projects. To make this possible, the other projects must be exported as a reference. MSVC does otherwise not wait for the compilation to finish.

Right now, project references are not exported for static libraries. And while `ExportAdditionalLibrariesEvenForStaticLib` exists as a configuration option, it does more things at once, often resulting in `already defined in X.lib(X.dll); second definition ignored` warnings.

Therefore, this pull request adds an option to force the export of these references regardless of the output type of the project.