### PR TITLE
Add FastBuild UnityInputIsolateListFile support

### DIFF
--- a/Sharpmake.FunctionalTests/FastBuildFunctionalTest/FastBuildFunctionalTest.sharpmake.cs
+++ b/Sharpmake.FunctionalTests/FastBuildFunctionalTest/FastBuildFunctionalTest.sharpmake.cs
@@ -309,6 +309,26 @@ namespace SharpmakeGen.FunctionalTests
     }
 
     [Generate]
+    public class SpanMultipleSrcDirsFBUnityIsolate : SpanMultipleSrcDirs
+    {
+        public SpanMultipleSrcDirsFBUnityIsolate()
+        {
+            AddFragmentMask(Blob.FastBuildUnitys);
+        }
+
+        public override void FastBuildUnitys(Configuration conf, Target target)
+        {
+            base.FastBuildUnitys(conf, target);
+
+            // Isolating writable files works well only for Perforce
+            conf.FastBuildUnityInputIsolateWritableFiles = false;
+
+            // Provides a list of files that should be manually isolated. It can be used for Git difference of names, for example
+            conf.FastBuildUnityInputIsolateListFile = @"[project.RootPath]\codebase\SpanMultipleSrcDirs\temp\isolate_list.txt";
+        }
+    }
+
+    [Generate]
     public class UsePrecompExe : CommonExeProject
     {
         public UsePrecompExe()
@@ -608,6 +628,7 @@ namespace SharpmakeGen.FunctionalTests
             {
                 conf.AddProject<SpanMultipleSrcDirsFBUnityInclude>(target);
                 conf.AddProject<SpanMultipleSrcDirsFBUnityExclude>(target);
+                conf.AddProject<SpanMultipleSrcDirsFBUnityIsolate>(target);
             }
             else if (target.Blob == Blob.NoBlob)
             {

--- a/Sharpmake.FunctionalTests/FastBuildFunctionalTest/codebase/SpanMultipleSrcDirs/temp/isolate_list.txt
+++ b/Sharpmake.FunctionalTests/FastBuildFunctionalTest/codebase/SpanMultipleSrcDirs/temp/isolate_list.txt
@@ -1,0 +1,2 @@
+../codebase/SpanMultipleSrcDirs/additional_dir/extra_class1.cpp
+../codebase/SpanMultipleSrcDirs/main_dir/main.cpp

--- a/Sharpmake.FunctionalTests/FastBuildFunctionalTest/reference/projects/fastbuildfunctionaltest.bff
+++ b/Sharpmake.FunctionalTests/FastBuildFunctionalTest/reference/projects/fastbuildfunctionaltest.bff
@@ -41,6 +41,7 @@ Exec( 'GenerateHeader' )
 #include ".\simpleexewithlib_vs2019_win64.bff"
 #include ".\spanmultiplesrcdirsfbunityexclude_vs2019_win64.bff"
 #include ".\spanmultiplesrcdirsfbunityinclude_vs2019_win64.bff"
+#include ".\spanmultiplesrcdirsfbunityisolate_vs2019_win64.bff"
 #include ".\useprecompexe_vs2019_win64.bff"
 #include ".\spanmultiplesrcdirsfbnoblobexclude_vs2019_win64.bff"
 #include ".\spanmultiplesrcdirsfbnoblobinclude_vs2019_win64.bff"

--- a/Sharpmake.FunctionalTests/FastBuildFunctionalTest/reference/projects/fastbuildfunctionaltest.sln
+++ b/Sharpmake.FunctionalTests/FastBuildFunctionalTest/reference/projects/fastbuildfunctionaltest.sln
@@ -40,6 +40,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "SpanMultipleSrcDirsFBUnityE
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "SpanMultipleSrcDirsFBUnityInclude", "spanmultiplesrcdirsfbunityinclude_vs2019_win64.vcxproj", "{4CAA3DED-3DBD-71FD-8F76-B3B8ADFA2035}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "SpanMultipleSrcDirsFBUnityIsolate", "spanmultiplesrcdirsfbunityisolate_vs2019_win64.vcxproj", "{CB3DB407-EB24-B12A-AAFB-A3BFFCA31040}"
+EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "UsePrecompExe", "useprecompexe_vs2019_win64.vcxproj", "{3B88798D-8E0B-330F-7C31-7F761D686B03}"
 EndProject
 Global
@@ -174,6 +176,12 @@ Global
 		{4CAA3DED-3DBD-71FD-8F76-B3B8ADFA2035}.Release|FastBuild.ActiveCfg = Release_FastBuild_vs2019|x64
 		{4CAA3DED-3DBD-71FD-8F76-B3B8ADFA2035}.Release|FastBuild_NoBlob.ActiveCfg = Release_FastBuild_vs2019|x64
 		{4CAA3DED-3DBD-71FD-8F76-B3B8ADFA2035}.Release|MSBuild.ActiveCfg = Release_FastBuild_vs2019|x64
+		{CB3DB407-EB24-B12A-AAFB-A3BFFCA31040}.Debug|FastBuild.ActiveCfg = Debug_FastBuild_vs2019|x64
+		{CB3DB407-EB24-B12A-AAFB-A3BFFCA31040}.Debug|FastBuild_NoBlob.ActiveCfg = Debug_FastBuild_vs2019|x64
+		{CB3DB407-EB24-B12A-AAFB-A3BFFCA31040}.Debug|MSBuild.ActiveCfg = Debug_FastBuild_vs2019|x64
+		{CB3DB407-EB24-B12A-AAFB-A3BFFCA31040}.Release|FastBuild.ActiveCfg = Release_FastBuild_vs2019|x64
+		{CB3DB407-EB24-B12A-AAFB-A3BFFCA31040}.Release|FastBuild_NoBlob.ActiveCfg = Release_FastBuild_vs2019|x64
+		{CB3DB407-EB24-B12A-AAFB-A3BFFCA31040}.Release|MSBuild.ActiveCfg = Release_FastBuild_vs2019|x64
 		{3B88798D-8E0B-330F-7C31-7F761D686B03}.Debug|FastBuild.ActiveCfg = Debug_FastBuild_vs2019|x64
 		{3B88798D-8E0B-330F-7C31-7F761D686B03}.Debug|FastBuild_NoBlob.ActiveCfg = Debug_FastBuild_NoBlob_vs2019|x64
 		{3B88798D-8E0B-330F-7C31-7F761D686B03}.Debug|MSBuild.ActiveCfg = Debug_MSBuild_vs2019|x64

--- a/Sharpmake.FunctionalTests/FastBuildFunctionalTest/reference/projects/fastbuildfunctionaltest_all.bff
+++ b/Sharpmake.FunctionalTests/FastBuildFunctionalTest/reference/projects/fastbuildfunctionaltest_all.bff
@@ -64,6 +64,7 @@ Alias( 'FastBuildFunctionalTest_All_Debug_FastBuild_vs2019_win64' )
                    'SimpleExeWithLib_Debug_FastBuild_vs2019_win64',
                    'SpanMultipleSrcDirsFBUnityExclude_Debug_FastBuild_vs2019_win64',
                    'SpanMultipleSrcDirsFBUnityInclude_Debug_FastBuild_vs2019_win64',
+                   'SpanMultipleSrcDirsFBUnityIsolate_Debug_FastBuild_vs2019_win64',
                    'UsePrecompExe_Debug_FastBuild_vs2019_win64'
                }
 }
@@ -84,6 +85,7 @@ Alias( 'FastBuildFunctionalTest_All_Release_FastBuild_vs2019_win64' )
                    'SimpleExeWithLib_Release_FastBuild_vs2019_win64',
                    'SpanMultipleSrcDirsFBUnityExclude_Release_FastBuild_vs2019_win64',
                    'SpanMultipleSrcDirsFBUnityInclude_Release_FastBuild_vs2019_win64',
+                   'SpanMultipleSrcDirsFBUnityIsolate_Release_FastBuild_vs2019_win64',
                    'UsePrecompExe_Release_FastBuild_vs2019_win64'
                }
 }

--- a/Sharpmake.FunctionalTests/FastBuildFunctionalTest/reference/projects/spanmultiplesrcdirsfbunityisolate_vs2019_win64.bff
+++ b/Sharpmake.FunctionalTests/FastBuildFunctionalTest/reference/projects/spanmultiplesrcdirsfbunityisolate_vs2019_win64.bff
@@ -1,0 +1,309 @@
+
+//=================================================================================================================
+// SpanMultipleSrcDirsFBUnityIsolate FASTBuild config file
+//=================================================================================================================
+#once
+
+
+Unity( 'SpanMultipleSrcDirsFBUnityIsolate_unity' )
+{
+    .UnityInputPath                     = {
+                                              '.\$_CURRENT_BFF_DIR_$\..\codebase\SpanMultipleSrcDirs\additional_dir',
+                                              '.\$_CURRENT_BFF_DIR_$\..\codebase\SpanMultipleSrcDirs\main_dir'
+                                          }
+    .UnityInputFiles                    = {
+                                              '.\$_CURRENT_BFF_DIR_$\..\codebase\SpanMultipleSrcDirs\dir_individual_files\floating_class.cpp',
+                                              '.\$_CURRENT_BFF_DIR_$\..\codebase\SpanMultipleSrcDirs\dir_individual_files\floating_file.cpp'
+                                          }
+    .UnityInputIsolateWritableFiles     =  false
+    .UnityInputIsolateListFile          = '.\$_CURRENT_BFF_DIR_$\..\codebase\SpanMultipleSrcDirs\temp\isolate_list.txt'
+    .UnityOutputPath                    = '.\$_CURRENT_BFF_DIR_$\unity\SpanMultipleSrcDirsFBUnityIsolate'
+    .UnityOutputPattern                 = 'spanmultiplesrcdirsfbunityisolate_unity*.cpp'
+    .UnityNumFiles                      =  1
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// PLATFORM SPECIFIC SECTION
+#if WIN64
+
+//=================================================================================================================
+ObjectList( 'SpanMultipleSrcDirsFBUnityIsolate_Debug_FastBuild_vs2019_win64_objects' )
+{
+    Using( .win64Config )
+    .Intermediate           = '.\$_CURRENT_BFF_DIR_$\build\debug_fastbuild_vs2019\spanmultiplesrcdirsfbunityisolate\'
+
+    .CompilerExtraOptions   = ''
+            + ' /I".\$_CURRENT_BFF_DIR_$\..\codebase\spanmultiplesrcdirs\additional_dir"'
+            + ' /I".\$_CURRENT_BFF_DIR_$\..\codebase\spanmultiplesrcdirs\dir_individual_files"'
+            + ' /I"C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Tools\MSVC\14.29.30133\include"'
+            + ' /I"C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Tools\MSVC\14.29.30133\atlmfc\include"'
+            + ' /I"C:\Program Files (x86)\Windows Kits\10\Include\10.0.19041.0\um"'
+            + ' /I"C:\Program Files (x86)\Windows Kits\10\Include\10.0.19041.0\shared"'
+            + ' /I"C:\Program Files (x86)\Windows Kits\10\Include\10.0.19041.0\winrt"'
+            + ' /I"C:\Program Files (x86)\Windows Kits\10\Include\10.0.19041.0\ucrt"'
+            + ' /Zi'
+            + ' /nologo'
+            + ' /W4'
+            + ' /WX-'
+            + ' /D"WIN64"'
+            + ' /D"_CONSOLE"'
+            + ' /D"_DEBUG"'
+            + ' /GF'
+            + ' /MTd'
+            + ' /GS'
+            + ' /Gy-'
+            + ' /fp:fast'
+            + ' /fp:except-'
+            + ' /Zc:wchar_t'
+            + ' /Zc:forScope'
+            + ' /Zc:inline'
+            + ' /GR-'
+            + ' /openmp-'
+            + ' /Fd".\$_CURRENT_BFF_DIR_$\build\debug_fastbuild_vs2019\spanmultiplesrcdirsfbunityisolate\spanmultiplesrcdirsfbunityisolate_compiler.pdb"'
+            + ' /Gd'
+            + ' /TP'
+            + ' /errorReport:queue'
+            + ' /D"_MBCS"'
+            + ' /FS /Zc:__cplusplus'
+
+    .CompilerOptimizations = ''
+            + ' /Od'
+            + ' /Ob1'
+            + ' /Oi'
+            + ' /Oy-'
+
+    // Compiler options
+    // ----------------
+    .CompilerOptions        = '"%1" /Fo"%2" /c'
+                            + ' $CompilerExtraOptions$'
+                            + ' $CompilerOptimizations$'
+
+    .CompilerInputUnity       = 'SpanMultipleSrcDirsFBUnityIsolate_unity'
+    .CompilerOutputPath       = '$Intermediate$'
+
+}
+
+
+//=================================================================================================================
+Executable( 'SpanMultipleSrcDirsFBUnityIsolate_Debug_FastBuild_vs2019_win64_Executable' )
+{
+    Using( .win64Config )
+    .Intermediate           = '.\$_CURRENT_BFF_DIR_$\build\debug_fastbuild_vs2019\spanmultiplesrcdirsfbunityisolate\'
+    .Libraries              = 'SpanMultipleSrcDirsFBUnityIsolate_Debug_FastBuild_vs2019_win64_objects'
+    .LinkerOutput           = '.\$_CURRENT_BFF_DIR_$\output\debug_fastbuild_vs2019\spanmultiplesrcdirsfbunityisolate.exe'
+    .LinkerLinkObjects      = false
+
+    .LinkerOptions          = '/OUT:"%2"'
+                            // Input files
+                            // ---------------------------
+                            + ' "%1"'
+                            // General
+                            // ---------------------------
+                            + ' /INCREMENTAL:NO'
+                            + ' /NOLOGO'
+                            + ' /LIBPATH:"C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Tools\MSVC\14.29.30133\lib\x64"'
+                            + ' /LIBPATH:"C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Tools\MSVC\14.29.30133\atlmfc\lib\x64"'
+                            + ' /LIBPATH:"C:\Program Files (x86)\Windows Kits\10\Lib\10.0.19041.0\ucrt\x64"'
+                            + ' /LIBPATH:"C:\Program Files (x86)\Windows Kits\10\Lib\10.0.19041.0\um\x64"'
+                            // Input
+                            // ---------------------------
+                            + ' "kernel32.lib"'
+                            + ' "user32.lib"'
+                            + ' "gdi32.lib"'
+                            + ' "winspool.lib"'
+                            + ' "comdlg32.lib"'
+                            + ' "advapi32.lib"'
+                            + ' "shell32.lib"'
+                            + ' "ole32.lib"'
+                            + ' "oleaut32.lib"'
+                            + ' "uuid.lib"'
+                            + ' "odbc32.lib"'
+                            + ' "odbccp32.lib"'
+                            // Manifest
+                            // ---------------------------
+                            + ' /MANIFEST /MANIFESTUAC:"level=^'asInvoker^' uiAccess=^'false^'"'
+                            + ' /ManifestFile:".\$_CURRENT_BFF_DIR_$\build\debug_fastbuild_vs2019\spanmultiplesrcdirsfbunityisolate\spanmultiplesrcdirsfbunityisolate.intermediate.manifest"'
+                            // Debugging
+                            // ---------------------------
+                            + ' /DEBUG'
+                            + ' /PDB:".\$_CURRENT_BFF_DIR_$\output\debug_fastbuild_vs2019\spanmultiplesrcdirsfbunityisolate.pdb"'
+                            + ' /MAP":.\$_CURRENT_BFF_DIR_$\output\debug_fastbuild_vs2019\spanmultiplesrcdirsfbunityisolate.map"'
+                            // System
+                            // ---------------------------
+                            + ' /SUBSYSTEM:CONSOLE'
+                            + ' /LARGEADDRESSAWARE'
+                            // Optimization
+                            // ---------------------------
+                            + ' /OPT:NOREF'
+                            + ' /OPT:NOICF'
+                            // Embedded IDL
+                            // ---------------------------
+                            + ' /TLBID:1'
+                            // Windows Metadata
+                            // ---------------------------
+                            // Advanced
+                            // ---------------------------
+                            + ' /DYNAMICBASE'
+                            + ' /MACHINE:X64'
+                            + ' /errorReport:queue'
+                            // Additional linker options
+                            //--------------------------
+}
+
+
+//=================================================================================================================
+Alias( 'SpanMultipleSrcDirsFBUnityIsolate_Debug_FastBuild_vs2019_win64' )
+{
+    .Targets = 'SpanMultipleSrcDirsFBUnityIsolate_Debug_FastBuild_vs2019_win64_Executable'
+}
+
+
+//=================================================================================================================
+Alias( 'SpanMultipleSrcDirsFBUnityIsolate_Debug_FastBuild_vs2019_win64_LibraryDependency' )
+{
+    .Targets = 'SpanMultipleSrcDirsFBUnityIsolate_Debug_FastBuild_vs2019_win64_Executable'
+}
+
+
+//=================================================================================================================
+ObjectList( 'SpanMultipleSrcDirsFBUnityIsolate_Release_FastBuild_vs2019_win64_objects' )
+{
+    Using( .win64Config )
+    .Intermediate           = '.\$_CURRENT_BFF_DIR_$\build\release_fastbuild_vs2019\spanmultiplesrcdirsfbunityisolate\'
+
+    .CompilerExtraOptions   = ''
+            + ' /I".\$_CURRENT_BFF_DIR_$\..\codebase\spanmultiplesrcdirs\additional_dir"'
+            + ' /I".\$_CURRENT_BFF_DIR_$\..\codebase\spanmultiplesrcdirs\dir_individual_files"'
+            + ' /I"C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Tools\MSVC\14.29.30133\include"'
+            + ' /I"C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Tools\MSVC\14.29.30133\atlmfc\include"'
+            + ' /I"C:\Program Files (x86)\Windows Kits\10\Include\10.0.19041.0\um"'
+            + ' /I"C:\Program Files (x86)\Windows Kits\10\Include\10.0.19041.0\shared"'
+            + ' /I"C:\Program Files (x86)\Windows Kits\10\Include\10.0.19041.0\winrt"'
+            + ' /I"C:\Program Files (x86)\Windows Kits\10\Include\10.0.19041.0\ucrt"'
+            + ' /Zi'
+            + ' /nologo'
+            + ' /W4'
+            + ' /WX-'
+            + ' /D"NDEBUG"'
+            + ' /D"WIN64"'
+            + ' /D"_CONSOLE"'
+            + ' /GF'
+            + ' /MT'
+            + ' /GS-'
+            + ' /Gy'
+            + ' /fp:fast'
+            + ' /fp:except-'
+            + ' /Zc:wchar_t'
+            + ' /Zc:forScope'
+            + ' /Zc:inline'
+            + ' /GR-'
+            + ' /openmp-'
+            + ' /Fd".\$_CURRENT_BFF_DIR_$\build\release_fastbuild_vs2019\spanmultiplesrcdirsfbunityisolate\spanmultiplesrcdirsfbunityisolate_compiler.pdb"'
+            + ' /Gd'
+            + ' /TP'
+            + ' /errorReport:queue'
+            + ' /D"_MBCS"'
+            + ' /FS /Zc:__cplusplus'
+
+    .CompilerOptimizations = ''
+            + ' /Ox'
+            + ' /Ob2'
+            + ' /Oi'
+            + ' /Ot'
+            + ' /Oy-'
+
+    // Compiler options
+    // ----------------
+    .CompilerOptions        = '"%1" /Fo"%2" /c'
+                            + ' $CompilerExtraOptions$'
+                            + ' $CompilerOptimizations$'
+
+    .CompilerInputUnity       = 'SpanMultipleSrcDirsFBUnityIsolate_unity'
+    .CompilerOutputPath       = '$Intermediate$'
+
+}
+
+
+//=================================================================================================================
+Executable( 'SpanMultipleSrcDirsFBUnityIsolate_Release_FastBuild_vs2019_win64_Executable' )
+{
+    Using( .win64Config )
+    .Intermediate           = '.\$_CURRENT_BFF_DIR_$\build\release_fastbuild_vs2019\spanmultiplesrcdirsfbunityisolate\'
+    .Libraries              = 'SpanMultipleSrcDirsFBUnityIsolate_Release_FastBuild_vs2019_win64_objects'
+    .LinkerOutput           = '.\$_CURRENT_BFF_DIR_$\output\release_fastbuild_vs2019\spanmultiplesrcdirsfbunityisolate.exe'
+    .LinkerLinkObjects      = false
+
+    .LinkerOptions          = '/OUT:"%2"'
+                            // Input files
+                            // ---------------------------
+                            + ' "%1"'
+                            // General
+                            // ---------------------------
+                            + ' /INCREMENTAL:NO'
+                            + ' /NOLOGO'
+                            + ' /LIBPATH:"C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Tools\MSVC\14.29.30133\lib\x64"'
+                            + ' /LIBPATH:"C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Tools\MSVC\14.29.30133\atlmfc\lib\x64"'
+                            + ' /LIBPATH:"C:\Program Files (x86)\Windows Kits\10\Lib\10.0.19041.0\ucrt\x64"'
+                            + ' /LIBPATH:"C:\Program Files (x86)\Windows Kits\10\Lib\10.0.19041.0\um\x64"'
+                            // Input
+                            // ---------------------------
+                            + ' "kernel32.lib"'
+                            + ' "user32.lib"'
+                            + ' "gdi32.lib"'
+                            + ' "winspool.lib"'
+                            + ' "comdlg32.lib"'
+                            + ' "advapi32.lib"'
+                            + ' "shell32.lib"'
+                            + ' "ole32.lib"'
+                            + ' "oleaut32.lib"'
+                            + ' "uuid.lib"'
+                            + ' "odbc32.lib"'
+                            + ' "odbccp32.lib"'
+                            // Manifest
+                            // ---------------------------
+                            + ' /MANIFEST /MANIFESTUAC:"level=^'asInvoker^' uiAccess=^'false^'"'
+                            + ' /ManifestFile:".\$_CURRENT_BFF_DIR_$\build\release_fastbuild_vs2019\spanmultiplesrcdirsfbunityisolate\spanmultiplesrcdirsfbunityisolate.intermediate.manifest"'
+                            // Debugging
+                            // ---------------------------
+                            + ' /DEBUG'
+                            + ' /PDB:".\$_CURRENT_BFF_DIR_$\output\release_fastbuild_vs2019\spanmultiplesrcdirsfbunityisolate.pdb"'
+                            + ' /MAP":.\$_CURRENT_BFF_DIR_$\output\release_fastbuild_vs2019\spanmultiplesrcdirsfbunityisolate.map"'
+                            // System
+                            // ---------------------------
+                            + ' /SUBSYSTEM:CONSOLE'
+                            + ' /LARGEADDRESSAWARE'
+                            // Optimization
+                            // ---------------------------
+                            + ' /OPT:REF'
+                            + ' /OPT:ICF'
+                            // Embedded IDL
+                            // ---------------------------
+                            + ' /TLBID:1'
+                            // Windows Metadata
+                            // ---------------------------
+                            // Advanced
+                            // ---------------------------
+                            + ' /DYNAMICBASE'
+                            + ' /MACHINE:X64'
+                            + ' /errorReport:queue'
+                            // Additional linker options
+                            //--------------------------
+}
+
+
+//=================================================================================================================
+Alias( 'SpanMultipleSrcDirsFBUnityIsolate_Release_FastBuild_vs2019_win64' )
+{
+    .Targets = 'SpanMultipleSrcDirsFBUnityIsolate_Release_FastBuild_vs2019_win64_Executable'
+}
+
+
+//=================================================================================================================
+Alias( 'SpanMultipleSrcDirsFBUnityIsolate_Release_FastBuild_vs2019_win64_LibraryDependency' )
+{
+    .Targets = 'SpanMultipleSrcDirsFBUnityIsolate_Release_FastBuild_vs2019_win64_Executable'
+}
+
+
+#endif // WIN64
+////////////////////////////////////////////////////////////////////////////////

--- a/Sharpmake.FunctionalTests/FastBuildFunctionalTest/reference/projects/spanmultiplesrcdirsfbunityisolate_vs2019_win64.vcxproj
+++ b/Sharpmake.FunctionalTests/FastBuildFunctionalTest/reference/projects/spanmultiplesrcdirsfbunityisolate_vs2019_win64.vcxproj
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="16.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug_FastBuild_vs2019|x64">
+      <Configuration>Debug_FastBuild_vs2019</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release_FastBuild_vs2019|x64">
+      <Configuration>Release_FastBuild_vs2019</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{CB3DB407-EB24-B12A-AAFB-A3BFFCA31040}</ProjectGuid>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <RootNamespace>SpanMultipleSrcDirsFBUnityIsolate</RootNamespace>
+    <ProjectName>SpanMultipleSrcDirsFBUnityIsolate</ProjectName>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_FastBuild_vs2019|x64'" Label="Configuration">
+    <ConfigurationType>Makefile</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>MultiByte</CharacterSet>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_FastBuild_vs2019|x64'" Label="Configuration">
+    <ConfigurationType>Makefile</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <CharacterSet>MultiByte</CharacterSet>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_FastBuild_vs2019|x64'">
+    <OutDir>output\debug_fastbuild_vs2019\</OutDir>
+    <IntDir>build\debug_fastbuild_vs2019\spanmultiplesrcdirsfbunityisolate\</IntDir>
+    <NMakeBuildCommandLine>cd $(SolutionDir)
+"$(ProjectDir)..\..\..\tools\FastBuild\Windows-x64\FBuild.exe" SpanMultipleSrcDirsFBUnityIsolate_Debug_FastBuild_vs2019_win64 -ide -summary -wait -config $(SolutionName).bff </NMakeBuildCommandLine>
+    <NMakeReBuildCommandLine>cd $(SolutionDir)
+"$(ProjectDir)..\..\..\tools\FastBuild\Windows-x64\FBuild.exe" -clean SpanMultipleSrcDirsFBUnityIsolate_Debug_FastBuild_vs2019_win64 -ide -summary -wait -config $(SolutionName).bff </NMakeReBuildCommandLine>
+    <NMakeCleanCommandLine>del "build\debug_fastbuild_vs2019\spanmultiplesrcdirsfbunityisolate\*unity*.cpp" &gt;NUL 2&gt;NUL
+del "build\debug_fastbuild_vs2019\spanmultiplesrcdirsfbunityisolate\*.obj" &gt;NUL 2&gt;NUL
+del "build\debug_fastbuild_vs2019\spanmultiplesrcdirsfbunityisolate\*.a" &gt;NUL 2&gt;NUL
+del "build\debug_fastbuild_vs2019\spanmultiplesrcdirsfbunityisolate\*.lib" &gt;NUL 2&gt;NUL
+del "output\debug_fastbuild_vs2019\spanmultiplesrcdirsfbunityisolate.exe" &gt;NUL 2&gt;NUL
+del "output\debug_fastbuild_vs2019\spanmultiplesrcdirsfbunityisolate.elf" &gt;NUL 2&gt;NUL
+del "output\debug_fastbuild_vs2019\spanmultiplesrcdirsfbunityisolate.exp" &gt;NUL 2&gt;NUL
+del "output\debug_fastbuild_vs2019\spanmultiplesrcdirsfbunityisolate.ilk" &gt;NUL 2&gt;NUL
+del "output\debug_fastbuild_vs2019\spanmultiplesrcdirsfbunityisolate.lib" &gt;NUL 2&gt;NUL
+del "output\debug_fastbuild_vs2019\spanmultiplesrcdirsfbunityisolate.pdb" &gt;NUL 2&gt;NUL</NMakeCleanCommandLine>
+    <NMakeOutput>output\debug_fastbuild_vs2019\spanmultiplesrcdirsfbunityisolate.exe</NMakeOutput>
+    <NMakePreprocessorDefinitions>WIN64;_CONSOLE;_DEBUG</NMakePreprocessorDefinitions>
+    <NMakeIncludeSearchPath>..\codebase\spanmultiplesrcdirs\additional_dir;..\codebase\spanmultiplesrcdirs\dir_individual_files</NMakeIncludeSearchPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_FastBuild_vs2019|x64'">
+    <OutDir>output\release_fastbuild_vs2019\</OutDir>
+    <IntDir>build\release_fastbuild_vs2019\spanmultiplesrcdirsfbunityisolate\</IntDir>
+    <NMakeBuildCommandLine>cd $(SolutionDir)
+"$(ProjectDir)..\..\..\tools\FastBuild\Windows-x64\FBuild.exe" SpanMultipleSrcDirsFBUnityIsolate_Release_FastBuild_vs2019_win64 -ide -summary -wait -config $(SolutionName).bff </NMakeBuildCommandLine>
+    <NMakeReBuildCommandLine>cd $(SolutionDir)
+"$(ProjectDir)..\..\..\tools\FastBuild\Windows-x64\FBuild.exe" -clean SpanMultipleSrcDirsFBUnityIsolate_Release_FastBuild_vs2019_win64 -ide -summary -wait -config $(SolutionName).bff </NMakeReBuildCommandLine>
+    <NMakeCleanCommandLine>del "build\release_fastbuild_vs2019\spanmultiplesrcdirsfbunityisolate\*unity*.cpp" &gt;NUL 2&gt;NUL
+del "build\release_fastbuild_vs2019\spanmultiplesrcdirsfbunityisolate\*.obj" &gt;NUL 2&gt;NUL
+del "build\release_fastbuild_vs2019\spanmultiplesrcdirsfbunityisolate\*.a" &gt;NUL 2&gt;NUL
+del "build\release_fastbuild_vs2019\spanmultiplesrcdirsfbunityisolate\*.lib" &gt;NUL 2&gt;NUL
+del "output\release_fastbuild_vs2019\spanmultiplesrcdirsfbunityisolate.exe" &gt;NUL 2&gt;NUL
+del "output\release_fastbuild_vs2019\spanmultiplesrcdirsfbunityisolate.elf" &gt;NUL 2&gt;NUL
+del "output\release_fastbuild_vs2019\spanmultiplesrcdirsfbunityisolate.exp" &gt;NUL 2&gt;NUL
+del "output\release_fastbuild_vs2019\spanmultiplesrcdirsfbunityisolate.ilk" &gt;NUL 2&gt;NUL
+del "output\release_fastbuild_vs2019\spanmultiplesrcdirsfbunityisolate.lib" &gt;NUL 2&gt;NUL
+del "output\release_fastbuild_vs2019\spanmultiplesrcdirsfbunityisolate.pdb" &gt;NUL 2&gt;NUL</NMakeCleanCommandLine>
+    <NMakeOutput>output\release_fastbuild_vs2019\spanmultiplesrcdirsfbunityisolate.exe</NMakeOutput>
+    <NMakePreprocessorDefinitions>NDEBUG;WIN64;_CONSOLE</NMakePreprocessorDefinitions>
+    <NMakeIncludeSearchPath>..\codebase\spanmultiplesrcdirs\additional_dir;..\codebase\spanmultiplesrcdirs\dir_individual_files</NMakeIncludeSearchPath>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="spanmultiplesrcdirsfbunityisolate_vs2019_win64.bff" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Sharpmake.Generators/FastBuild/Bff.Template.cs
+++ b/Sharpmake.Generators/FastBuild/Bff.Template.cs
@@ -571,6 +571,7 @@ Unity( '[unityFile.UnityName]' )
     .UnityInputObjectLists              = [unityFile.UnityInputObjectLists]
     .UnityInputIsolateWritableFiles     =  [unityFile.UnityInputIsolateWritableFiles]
     .UnityInputIsolateWritableFilesLimit = [unityFile.UnityInputIsolateWritableFilesLimit]
+    .UnityInputIsolateListFile          = '[unityFile.UnityInputIsolateListFile]'
     .UnityOutputPath                    = '[unityFile.UnityOutputPath]'
     .UnityOutputPattern                 = '[unityFile.UnityOutputPattern]'
     .UnityNumFiles                      =  [unityFile.UnityNumFiles]

--- a/Sharpmake.Generators/FastBuild/Bff.Util.cs
+++ b/Sharpmake.Generators/FastBuild/Bff.Util.cs
@@ -37,6 +37,7 @@ namespace Sharpmake.Generators.FastBuild
             public string UnityInputObjectLists = FileGeneratorUtilities.RemoveLineTag; // (optional) ObjectList(s) to use as input
             public string UnityInputIsolateWritableFiles = FileGeneratorUtilities.RemoveLineTag; // (optional) Build writable files individually (default false)
             public string UnityInputIsolateWritableFilesLimit = FileGeneratorUtilities.RemoveLineTag; // (optional) Disable isolation when many files are writable (default 0)
+            public string UnityInputIsolateListFile = FileGeneratorUtilities.RemoveLineTag; // (optional) Text file containing list of files to isolate
             public string UnityOutputPattern = FileGeneratorUtilities.RemoveLineTag; // (optional) Pattern of output Unity file names (default Unity*cpp)
             public string UnityNumFiles = FileGeneratorUtilities.RemoveLineTag; // (optional) Number of Unity files to generate (default 1)
             public string UnityPCH = FileGeneratorUtilities.RemoveLineTag; // (optional) Precompiled Header file to add to generated Unity files
@@ -64,6 +65,7 @@ namespace Sharpmake.Generators.FastBuild
                     hash = hash * 23 + UnityInputObjectLists.GetDeterministicHashCode();
                     hash = hash * 23 + UnityInputIsolateWritableFiles.GetDeterministicHashCode();
                     hash = hash * 23 + UnityInputIsolateWritableFilesLimit.GetDeterministicHashCode();
+                    hash = hash * 23 + UnityInputIsolateListFile.GetDeterministicHashCode();
                     hash = hash * 23 + UnityOutputPattern.GetDeterministicHashCode();
                     hash = hash * 23 + UnityNumFiles.GetDeterministicHashCode();
                     hash = hash * 23 + UnityPCH.GetDeterministicHashCode();
@@ -99,6 +101,7 @@ namespace Sharpmake.Generators.FastBuild
                     && string.Equals(UnityInputObjectLists, unity.UnityInputObjectLists)
                     && string.Equals(UnityInputIsolateWritableFiles, unity.UnityInputIsolateWritableFiles)
                     && string.Equals(UnityInputIsolateWritableFilesLimit, unity.UnityInputIsolateWritableFilesLimit)
+                    && string.Equals(UnityInputIsolateListFile, unity.UnityInputIsolateListFile)
                     && string.Equals(UnityOutputPattern, unity.UnityOutputPattern)
                     && string.Equals(UnityNumFiles, unity.UnityNumFiles)
                     && string.Equals(UnityPCH, unity.UnityPCH)

--- a/Sharpmake.Generators/FastBuild/Bff.cs
+++ b/Sharpmake.Generators/FastBuild/Bff.cs
@@ -1811,6 +1811,8 @@ namespace Sharpmake.Generators.FastBuild
 
             var fastbuildUnityInputExcludePathList = new Strings(project.SourcePathsBlobExclude.Select(Util.GetCapitalizedPath));
 
+            string fastBuildUnityInputIsolateListFile = FileGeneratorUtilities.RemoveLineTag;
+
             bool srcDirsAreEmpty = true;
             var items = new List<string>();
 
@@ -1914,6 +1916,9 @@ namespace Sharpmake.Generators.FastBuild
                 fastBuildUnityInputPattern = UtilityMethods.FBuildCollectionFormat(inputPatterns, spaceLength);
             }
 
+            if (!string.IsNullOrEmpty(conf.FastBuildUnityInputIsolateListFile))
+                fastBuildUnityInputIsolateListFile = CurrentBffPathKeyCombine(Util.PathGetRelative(context.ProjectDirectoryCapitalized, conf.FastBuildUnityInputIsolateListFile, true));
+
             Unity unityFile = new Unity
             {
                 // Note that the UnityName and UnityOutputPattern are intentionally left empty: they will be set in the Resolve
@@ -1921,6 +1926,7 @@ namespace Sharpmake.Generators.FastBuild
                 UnityFullOutputPath = Path.Combine(context.ProjectDirectoryCapitalized, conf.FastBuildUnityPath),
                 UnityInputIsolateWritableFiles = conf.FastBuildUnityInputIsolateWritableFiles.ToString().ToLower(),
                 UnityInputIsolateWritableFilesLimit = conf.FastBuildUnityInputIsolateWritableFiles ? conf.FastBuildUnityInputIsolateWritableFilesLimit.ToString() : FileGeneratorUtilities.RemoveLineTag,
+                UnityInputIsolateListFile = fastBuildUnityInputIsolateListFile,
                 UnityPCH = conf.PrecompHeader ?? FileGeneratorUtilities.RemoveLineTag,
                 UnityInputExcludePath = fastBuildUnityInputExcludePath,
                 UnityNumFiles = fastBuildUnityCount,

--- a/Sharpmake.UnitTests/BffUnityResolverTest.cs
+++ b/Sharpmake.UnitTests/BffUnityResolverTest.cs
@@ -68,12 +68,12 @@ namespace Sharpmake.UnitTests
             var unityLogNames = GetProjectUnityLogNames();
 
             var expectedLogNames = new List<string> {
-                    "SimpleProject_vs2017_Debug : SimpleProject_unity_C887618D",   // Debug and Release have the same unity config, so hash is identical.
-                    "SimpleProject_vs2017_Release : SimpleProject_unity_C887618D",
-                    "SimpleProject_vs2017_Retail : SimpleProject_unity_3A2FAD5B",
-                    "SimpleProject_vs2019_Debug : SimpleProject_unity_8C09C56F",   // vs2019 values follow same pattern (debug == release),
-                    "SimpleProject_vs2019_Release : SimpleProject_unity_8C09C56F", // but different hash values because of different conf.FastBuildUnityUseRelativePaths from vs2017.
-                    "SimpleProject_vs2019_Retail : SimpleProject_unity_C29895B3",
+                    "SimpleProject_vs2017_Debug : SimpleProject_unity_B213A137",   // Debug and Release have the same unity config, so hash is identical.
+                    "SimpleProject_vs2017_Release : SimpleProject_unity_B213A137",
+                    "SimpleProject_vs2017_Retail : SimpleProject_unity_F850C659",
+                    "SimpleProject_vs2019_Debug : SimpleProject_unity_A6BA8495",   // vs2019 values follow same pattern (debug == release),
+                    "SimpleProject_vs2019_Release : SimpleProject_unity_A6BA8495", // but different hash values because of different conf.FastBuildUnityUseRelativePaths from vs2017.
+                    "SimpleProject_vs2019_Retail : SimpleProject_unity_80CD78B1",
                 };
             CollectionAssert.AreEqual(expectedLogNames, unityLogNames);
         }

--- a/Sharpmake/Project.Configuration.cs
+++ b/Sharpmake/Project.Configuration.cs
@@ -1327,6 +1327,19 @@ namespace Sharpmake
             public int FastBuildUnityInputIsolateWritableFilesLimit = 10;
 
             /// <summary>
+            /// Gets or sets the path of the list with files to isolate,
+            /// e.g.: @"temp\IsolateFileList.txt".
+            /// </summary>
+            /// <remarks>
+            /// <note>
+            /// Files in this list will be excluded from the FASTBuild unity build.
+            /// Their path must be relative to the FASTBuild working directory.
+            /// This is usually the location of the MasterBff file.
+            /// </note>
+            /// </remarks>
+            public string FastBuildUnityInputIsolateListFile = null;
+
+            /// <summary>
             /// Custom Actions to do before invoking FastBuildExecutable.
             /// </summary>
             public string FastBuildCustomActionsBeforeBuildCommand = RemoveLineTag;


### PR DESCRIPTION
I have had to update the unity test for FASTBuild to reflect the hash change.

I have also added a functional test to represent the functionality of isolating files from a unity build.