### PR TITLE
Portable debug types for C# projects

### DIFF
--- a/Sharpmake.Generators/VisualStudio/Csproj.cs
+++ b/Sharpmake.Generators/VisualStudio/Csproj.cs
@@ -3249,6 +3249,8 @@ namespace Sharpmake.Generators.VisualStudio
             (
             Options.Option(Options.CSharp.DebugType.Full, () => { options["DebugType"] = "full"; }),
             Options.Option(Options.CSharp.DebugType.Pdbonly, () => { options["DebugType"] = "pdbonly"; }),
+            Options.Option(Options.CSharp.DebugType.Portable, () => { options["DebugType"] = "portable"; }),
+            Options.Option(Options.CSharp.DebugType.Embedded, () => { options["DebugType"] = "embedded"; }),
             Options.Option(Options.CSharp.DebugType.None, () => { options["DebugType"] = RemoveLineTag; })
             );
 

--- a/Sharpmake/Options.CSharp.cs
+++ b/Sharpmake/Options.CSharp.cs
@@ -82,6 +82,8 @@ namespace Sharpmake
                 Full,
                 [Default(DefaultTarget.Release)]
                 Pdbonly,
+                Portable,
+                Embedded,
                 None
             }
 


### PR DESCRIPTION
As of now, Sharpmake is only supporting the "default" debug type options for C# projects. Those are `full` and `pdbonly`. However, there are two more options for generating portable Program Debug Database as described in the Microsoft's documentation: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/code-generation

The portable and embedded options are useful for tools that support only the open-source standard: https://github.com/dotnet/core/blob/90ff62b74898499466bb8423d44bedf4b34bf9b0/Documentation/diagnostics/portable_pdb.md