### PR TITLE
Mark enum value DevEnv.xcode4ios as obsolete and throw error when used

### DIFF
--- a/Sharpmake/Target.cs
+++ b/Sharpmake/Target.cs
@@ -52,7 +52,7 @@ namespace Sharpmake
         /// <summary>
         /// iOS project with Xcode [deprecated]
         /// </summary>
-        [Obsolete("xcode4ios has been deprecated, please use 'xcode'", error: false)]
+        [Obsolete("xcode4ios has been deprecated, please use 'xcode'", error: true)]
         xcode4ios = 1 << 7,
 
         /// <summary>

--- a/Sharpmake/Target.cs
+++ b/Sharpmake/Target.cs
@@ -50,15 +50,15 @@ namespace Sharpmake
         vs2022 = 1 << 6,
 
         /// <summary>
+        /// Xcode projects
+        /// </summary>
+        xcode = 1 << 7,
+
+        /// <summary>
         /// iOS project with Xcode [deprecated]
         /// </summary>
         [Obsolete("xcode4ios has been deprecated, please use 'xcode'", error: true)]
         xcode4ios = 1 << 7,
-
-        /// <summary>
-        /// Xcode projects
-        /// </summary>
-        xcode = 1 << 7,
 
         /// <summary>
         /// Eclipse.


### PR DESCRIPTION
Hi,

This is a followup of a previous MR/PR that added `DevEnv.xcode` as alias to `DevEnv.xcode4ios`.

Cheers.