### PR TITLE
Fix MSBuild binary logs artifacts of build jobs and add them for samples jobs on GitHub CI

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Store MSBuild binary logs
         if: always()
         uses: actions/upload-artifact@v3
-        with: 
+        with:
           name: sharpmake-msbuild-logs-${{ github.sha }}
           path: Sharpmake_${{ matrix.configuration }}.binlog
 
@@ -113,11 +113,11 @@ jobs:
         shell: pwsh
         run: | # TODO: ideally here we should try and compile the generated json file
           .\RunSample.ps1 -sampleName "CompileCommandDatabase" -configuration ${{ matrix.configuration }} -framework ${{ matrix.framework }} -os ${{ matrix.os }}
-      
+
       - name: ConfigureOrder ${{ matrix.configuration }} ${{ matrix.os }}
         if: runner.os == 'Windows' && matrix.configuration == 'release'
         shell: pwsh
-        run: 
+        run:
           .\RunSample.ps1 -sampleName "ConfigureOrder" -configuration ${{ matrix.configuration }} -framework ${{ matrix.framework }} -os ${{ matrix.os }}
 
       - name: CPPCLI ${{ matrix.configuration }} ${{ matrix.os }}
@@ -168,7 +168,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          .\RunSample.ps1 -sampleName "FastBuildSimpleExecutable" -configuration ${{ matrix.configuration }} -framework ${{ matrix.framework }} -os ${{ matrix.os }} -vsVersionSuffix ${env:VS_VERSION_SUFFIX} 
+          .\RunSample.ps1 -sampleName "FastBuildSimpleExecutable" -configuration ${{ matrix.configuration }} -framework ${{ matrix.framework }} -os ${{ matrix.os }} -vsVersionSuffix ${env:VS_VERSION_SUFFIX}
 
       # Temp disable after Github VM update which updated the NDK and broke it
       # - name: HelloAndroid ${{ matrix.configuration }}
@@ -182,13 +182,13 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          .\RunSample.ps1 -sampleName "HelloClangCl" -configuration ${{ matrix.configuration }} -framework ${{ matrix.framework }} -os ${{ matrix.os }} -vsVersionSuffix ${env:VS_VERSION_SUFFIX} 
+          .\RunSample.ps1 -sampleName "HelloClangCl" -configuration ${{ matrix.configuration }} -framework ${{ matrix.framework }} -os ${{ matrix.os }} -vsVersionSuffix ${env:VS_VERSION_SUFFIX}
 
       - name: HelloEvents ${{ matrix.configuration }} ${{ matrix.os }}
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          .\RunSample.ps1 -sampleName "HelloEvents" -configuration ${{ matrix.configuration }} -framework ${{ matrix.framework }} -os ${{ matrix.os }} -vsVersionSuffix ${env:VS_VERSION_SUFFIX} 
+          .\RunSample.ps1 -sampleName "HelloEvents" -configuration ${{ matrix.configuration }} -framework ${{ matrix.framework }} -os ${{ matrix.os }} -vsVersionSuffix ${env:VS_VERSION_SUFFIX}
 
       - name: HelloLinux ${{ matrix.configuration }} ${{ matrix.os }}
         if: runner.os == 'Linux'

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -264,3 +264,10 @@ jobs:
         shell: pwsh
         run: |
           .\RunSample.ps1 -sampleName "vcpkg" -configuration ${{ matrix.configuration }} -framework ${{ matrix.framework }} -os ${{ matrix.os }} -vsVersionSuffix ${env:VS_VERSION_SUFFIX}
+
+      - name: Store MSBuild binary logs
+        if: ${{ failure() && runner.os == 'Windows' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: sharpmake-samples-msbuild-logs-${{ matrix.framework }}-${{ runner.os }}-${{ github.sha }}-${{ matrix.configuration }}
+          path: samples/**/*.binlog

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -37,7 +37,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: sharpmake-msbuild-logs-${{ github.sha }}
+          name: sharpmake-msbuild-logs-${{ matrix.framework }}-${{ runner.os }}-${{ github.sha }}-${{ matrix.configuration }}
           path: Sharpmake_${{ matrix.configuration }}.binlog
 
       - name: UnitTest ${{ matrix.framework }} - dotnet test


### PR DESCRIPTION
GitHub Actions changes:

- Build jobs artifact name used for MSBuild binary log was conflicting. They were overwritting each others artifact.
- Added MSBuild binary log artifact to samples jobs. Only stored on job failure.