### PR TITLE
Improve the performance on hot paths

### DIFF
--- a/Sharpmake/DependencyTracker.cs
+++ b/Sharpmake/DependencyTracker.cs
@@ -67,7 +67,7 @@ namespace Sharpmake
             Project projectFrom,
             Project.Configuration configFrom,
             IEnumerable<KeyValuePair<Type, ITarget>> dependencies,
-            IDictionary<KeyValuePair<Type, ITarget>, DependencySetting> dependenciesSetting
+            IDictionary<ValueTuple<Type, ITarget>, DependencySetting> dependenciesSetting
         )
         {
             lock (this)
@@ -77,8 +77,10 @@ namespace Sharpmake
                     TrackedConfiguration confFrom = FindConfiguration(projectFrom, configFrom);
                     TrackedConfiguration confTo = FindConfiguration(pair.Key, pair.Value);
 
+                    var key = new ValueTuple<Type, ITarget>(pair.Key, pair.Value);
+
                     DependencySetting dependencySetting;
-                    if (!dependenciesSetting.TryGetValue(pair, out dependencySetting))
+                    if (!dependenciesSetting.TryGetValue(key, out dependencySetting))
                         dependencySetting = DependencySetting.Default;
 
                     confFrom.AddDependency(confTo, dependencyType, dependencySetting);

--- a/Sharpmake/Options.cs
+++ b/Sharpmake/Options.cs
@@ -247,6 +247,7 @@ namespace Sharpmake
 
         private static ConcurrentDictionary<FieldInfo, object[]> s_cachedDefaultAttributes = new ConcurrentDictionary<FieldInfo, object[]>();
         private static ConcurrentDictionary<FieldInfo, object[]> s_cachedDevEnvAttributes = new ConcurrentDictionary<FieldInfo, object[]>();
+        private static ConcurrentDictionary<Type, FieldInfo[]> s_cachedFieldInfos = new ConcurrentDictionary<Type, FieldInfo[]>();
 
         public static void SelectOption(Configuration conf, params OptionAction[] options)
         {
@@ -319,7 +320,7 @@ namespace Sharpmake
 
                 foreach (Options.Default defaultOption in attributes)
                 {
-                    if (Util.FlagsTest(defaultOption.DefaultTarget, conf.DefaultOption))
+                    if (defaultOption.DefaultTarget.HasFlag(conf.DefaultOption))
                     {
                         object fieldValue = field.GetValue(optionType);
                         foreach (OptionAction optionAction in options)
@@ -364,14 +365,15 @@ namespace Sharpmake
                 return default(T);
 
             // find the default options
-            FieldInfo[] optionTypeFields = optionType.GetFields();
+            FieldInfo[] optionTypeFields = s_cachedFieldInfos.GetOrAdd(optionType, type => type.GetFields());
+
             foreach (FieldInfo field in optionTypeFields)
             {
                 object[] attributes = s_cachedDefaultAttributes.GetOrAdd(field, fi => fi.GetCustomAttributes(typeof(Options.Default), true));
 
                 foreach (Default defaultOption in attributes)
                 {
-                    if (Util.FlagsTest(defaultOption.DefaultTarget, defaultTarget))
+                    if (defaultOption.DefaultTarget.HasFlag(defaultTarget))
                     {
                         object fieldValue = field.GetValue(optionType);
                         return (T)fieldValue;

--- a/Sharpmake/Strings.cs
+++ b/Sharpmake/Strings.cs
@@ -118,7 +118,7 @@ namespace Sharpmake
     /// </summary>
     public class OrderableStrings : IList<string>  // IList<string> for resolver
     {
-        private HashSet<string> _hashSet = new HashSet<string>();
+        private HashSet<string> _hashSet;
 
         private struct StringEntry : IComparable<StringEntry>
         {
@@ -161,9 +161,10 @@ namespace Sharpmake
 
         public OrderableStrings()
         {
+            _hashSet = new HashSet<string>();
         }
 
-        public OrderableStrings(IEnumerable<string> strings)
+        public OrderableStrings(IEnumerable<string> strings) : this()
         {
             AddRange(strings);
         }
@@ -171,7 +172,7 @@ namespace Sharpmake
         public OrderableStrings(OrderableStrings other)
         {
             _list.AddRange(other._list);
-            _hashSet.UnionWith(other._hashSet);
+            _hashSet = new HashSet<string>(other._hashSet);
         }
 
         public string JoinStrings(string separator)

--- a/Sharpmake/UniqueList.cs
+++ b/Sharpmake/UniqueList.cs
@@ -62,29 +62,61 @@ namespace Sharpmake
             }
         }
 
+        private void AddCore(T value)
+        {
+            _hash.Add(value);
+        }
+
+        private void GrowCapacity(int by)
+        {
+#if NET5_0_OR_GREATER
+            _hash.EnsureCapacity(_hash.Count + by);
+#endif
+        }
+
         public void Add(T value1)
         {
-            AddRange(new[] { value1 });
+            ValidateReadOnly();
+            AddCore(value1);
+            _isDirty = true;
         }
 
         public void Add(T value1, T value2)
         {
-            AddRange(new[] { value1, value2 });
+            ValidateReadOnly();
+            AddCore(value1);
+            AddCore(value2);
+            _isDirty = true;
         }
 
         public void Add(T value1, T value2, T value3)
         {
-            AddRange(new[] { value1, value2, value3 });
+            ValidateReadOnly();
+            AddCore(value1);
+            AddCore(value2);
+            AddCore(value3);
+            _isDirty = true;
         }
 
         public void Add(T value1, T value2, T value3, T value4)
         {
-            AddRange(new[] { value1, value2, value3, value4 });
+            ValidateReadOnly();
+            AddCore(value1);
+            AddCore(value2);
+            AddCore(value3);
+            AddCore(value4);
+            _isDirty = true;
         }
 
         public void Add(T value1, T value2, T value3, T value4, T value5)
         {
-            AddRange(new[] { value1, value2, value3, value4, value5 });
+            ValidateReadOnly();
+            AddCore(value1);
+            AddCore(value2);
+            AddCore(value3);
+            AddCore(value4);
+            AddCore(value5);
+            _isDirty = true;
         }
 
         public void Add(params T[] values)
@@ -96,6 +128,32 @@ namespace Sharpmake
         {
             ValidateReadOnly();
             _hash.UnionWith(collection);
+            _isDirty = true;
+        }
+
+        public void AddRange(UniqueList<T> other)
+        {
+            ValidateReadOnly();
+            GrowCapacity(other.Count);
+
+            foreach (T value in other._hash)
+            {
+                AddCore(value);
+            }
+
+            _isDirty = true;
+        }
+
+        public void AddRange(IReadOnlyList<T> collection)
+        {
+            ValidateReadOnly();
+            GrowCapacity(collection.Count);
+
+            for (int i = 0; i < collection.Count; i++)
+            {
+                AddCore(collection[i]);
+            }
+
             _isDirty = true;
         }
 
@@ -268,7 +326,12 @@ namespace Sharpmake
 
         #region IEnumerable
 
-        public IEnumerator<T> GetEnumerator()
+        public List<T>.Enumerator GetEnumerator()
+        {
+            return Values.GetEnumerator();
+        }
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator()
         {
             return Values.GetEnumerator();
         }

--- a/Sharpmake/Util.cs
+++ b/Sharpmake/Util.cs
@@ -145,11 +145,13 @@ namespace Sharpmake
         /// <returns>true=equal, false=not equal</returns>
         private static bool AreStreamsEqual(Stream stream1, Stream stream2)
         {
+#if NET5_0_OR_GREATER
+            Span<byte> buffer1 = new byte[_FileStreamBufferSize];
+            Span<byte> buffer2 = new byte[_FileStreamBufferSize];
+#else
             var buffer1 = new byte[_FileStreamBufferSize];
             var buffer2 = new byte[_FileStreamBufferSize];
-
-            ReadOnlySpan<byte> span1 = new ReadOnlySpan<byte>(buffer1);
-            ReadOnlySpan<byte> span2 = new ReadOnlySpan<byte>(buffer2);
+#endif
 
             stream1.Position = 0;
             stream2.Position = 0;
@@ -157,8 +159,13 @@ namespace Sharpmake
             while (true)
             {
                 // Read from both streams
+#if NET5_0_OR_GREATER
+                int count1 = stream1.Read(buffer1);
+                int count2 = stream2.Read(buffer2);
+#else
                 int count1 = stream1.Read(buffer1, 0, _FileStreamBufferSize);
                 int count2 = stream2.Read(buffer2, 0, _FileStreamBufferSize);
+#endif
 
                 if (count1 != count2)
                     return false;
@@ -167,7 +174,7 @@ namespace Sharpmake
                     return true;
 
                 // Compare the streams efficiently without any copy.
-                if (!span1.SequenceEqual(span2))
+                if (!buffer1.SequenceEqual(buffer2))
                     return false;
             }
         }


### PR DESCRIPTION
This PR adds some small tweaks that improve the performance on some of the hot paths in Sharpmake.

Main improvements involve:
- Caching common reflection calls
- Avoiding allocations to lower the GC overhead
- Skip debug code when not running in debug configuration
- Use .NET 5+ methods if possible for better performance

In our own tests this brought down generating the solution to about 10 seconds instead of 20-24 seconds. This was tested by generating an existing solution again. Generating a solution from scratch would still take more time.

Original author of these changes is @MarchingCube