### PR TITLE
Add environment variable expansion to Include attribute

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -31,7 +31,9 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
 
     <!-- GitVersion -->
-    <GitVersion_NoNormalizeEnabled>true</GitVersion_NoNormalizeEnabled>
+    <GitVersion_NoFetchEnabled >true</GitVersion_NoFetchEnabled >
+    <GitVersion_NoNormalizeEnabled>false</GitVersion_NoNormalizeEnabled>
+    <GitVersion_CommandLineArguments Condition="$(ContinuousIntegrationBuild) == 'true'">-output buildserver</GitVersion_CommandLineArguments>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Sharpmake.UnitTests/SharpmakeFileParserTest.cs
+++ b/Sharpmake.UnitTests/SharpmakeFileParserTest.cs
@@ -267,6 +267,26 @@ namespace Sharpmake.UnitTests
 
             Assert.That(assemblerContext.Sources.Count, Is.EqualTo(0));
         }
+
+        [Test]
+        public void SimpleIncludeWithEnvironmentVariable()
+        {
+            Environment.SetEnvironmentVariable("SIMPLE_INCLUDE_ENV_VAR", "someotherproject");
+
+            const string sharpmakeIncludedFile = "someotherproject.sharpmake.cs";
+            string sharpmakeIncludeFullPath = Path.Combine(_fakeFileInfo.DirectoryName, sharpmakeIncludedFile);
+
+            Util.AddNewFakeFile(sharpmakeIncludedFile, 0);
+
+            string line = $@"[module: Sharpmake.Include(""%SIMPLE_INCLUDE_ENV_VAR%.sharpmake.cs"")]";
+
+            var assemblerContext = new AssemblerContext();
+            new Assembler().ParseSourceAttributesFromLine(line, _fakeFileInfo, _fakeFileLine, assemblerContext);
+
+            Assert.That(assemblerContext.Sources.Count, Is.EqualTo(1));
+            StringAssert.AreEqualIgnoringCase(sharpmakeIncludeFullPath, assemblerContext.Sources.First());
+        }
+
         #endregion
 
         #region Reference

--- a/Sharpmake/AttributeParsers.cs
+++ b/Sharpmake/AttributeParsers.cs
@@ -44,7 +44,7 @@ namespace Sharpmake
         }
         public override void ParseParameter(string[] parameters, FileInfo sourceFilePath, int lineNumber, IAssemblerContext context)
         {
-            string includeFilename = parameters[0];
+            string includeFilename = Environment.ExpandEnvironmentVariables(parameters[0]);
             IncludeType matchType = IncludeType.Relative;
             if (parameters.Length > 1)
             {


### PR DESCRIPTION
Hi folks,

It would be quite handy to use environment variables inside the path of module includes, like this:

`
[module:Include(@"%BUILD_TOOLS%\Tool1\SharpMake.Tool1.Project.cs")]
`

Do you think that's a good idea, or would you suggest a better alternative? If you think it's a useful feature, please consider reviewing this pull request.

Each environment variable is quoted with the percent sign character (%), the same behavior specified by `System.Environment.ExpandEnvironmentVariables`. 

Thank you!

Best regards,
Cesar