### PR TITLE
Add GitHub Actions release workflow

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -13,50 +13,21 @@ env:
   DOTNET_NOLOGO: true
 
 jobs:
-  build:
-    runs-on: ${{ matrix.os }}
+  builds:
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-2022]
         framework: [net6.0]
         configuration: [Debug, Release]
-
-    steps:
-      - name: Checkout the repo
-        uses: actions/checkout@v3.4.0
-        with:
-          fetch-depth: 0
-
-      - name: Build Sharpmake ${{ matrix.configuration }} ${{ matrix.os }}
-        shell: pwsh
-        run: |
-          dotnet build "Sharpmake.sln" -c "${{ matrix.configuration }}" -bl:Sharpmake_${{ matrix.configuration }}.binlog
-
-      - name: Store MSBuild binary logs
-        if: always()
-        uses: actions/upload-artifact@v3
-        with:
-          name: sharpmake-msbuild-logs-${{ matrix.framework }}-${{ runner.os }}-${{ github.sha }}-${{ matrix.configuration }}
-          path: Sharpmake_${{ matrix.configuration }}.binlog
-
-      - name: UnitTest ${{ matrix.framework }} - dotnet test
-        if: runner.os == 'Windows' # TODO: fix the tests on mac and linux and remove the first part of the if
-        run: dotnet test --no-build --no-restore Sharpmake.UnitTests/Sharpmake.UnitTests.csproj --framework ${{ matrix.framework }} --configuration ${{ matrix.configuration }}
-
-      - name: RegressionTest
-        if: runner.os == 'Windows'
-        run: python regression_test.py --sharpmake_exe "Sharpmake.Application\bin\${{ matrix.configuration }}\${{ matrix.framework }}\Sharpmake.Application.exe"
-
-      - name: Upload sharpmake ${{ matrix.framework }} ${{ runner.os }}-release binaries
-        if: matrix.configuration == 'release'
-        uses: actions/upload-artifact@v3
-        with:
-          name: 'Sharpmake-${{ matrix.framework }}-${{ runner.os }}-${{ github.sha }}'
-          path: Sharpmake.Application/bin/Release/${{ matrix.framework }}
+    uses: ./.github/workflows/build.yml
+    with:
+      os: ${{ matrix.os }}
+      framework: ${{ matrix.framework }}
+      configuration: ${{ matrix.configuration }}
 
   functional_test:
-    needs: [build]
+    needs: [builds]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -79,7 +50,7 @@ jobs:
         run: python functional_test.py --sharpmake_exe "Sharpmake.Application/bin/release/${{ matrix.framework }}/Sharpmake.Application.exe"
 
   samples:
-    needs: [build]
+    needs: [builds]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -2,6 +2,8 @@
 name: build
 on:
   push:
+    branches:
+      - '**'
   pull_request:
   schedule:
     # Run at 02:17 every day

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,65 @@
+# Sharpmake GitHub Actions build reusable workflow
+name: build
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        type: string
+      framework:
+        required: true
+        type: string
+      configuration:
+        required: true
+        type: string
+      run_unit_tests:
+        required: false
+        type: boolean
+        default: true
+      run_regression_tests:
+        required: false
+        type: boolean
+        default: true
+
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  DOTNET_NOLOGO: true
+
+jobs:
+  build:
+    runs-on: ${{ inputs.os }}
+
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v3.4.0
+        with:
+          fetch-depth: 0
+
+      - name: Build Sharpmake ${{ inputs.configuration }} ${{ inputs.os }}
+        shell: pwsh
+        run: |
+          dotnet build "Sharpmake.sln" -c "${{ inputs.configuration }}" -bl:Sharpmake_${{ inputs.configuration }}.binlog
+
+      - name: Store MSBuild binary logs
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: sharpmake-msbuild-logs-${{ inputs.framework }}-${{ runner.os }}-${{ github.sha }}-${{ inputs.configuration }}
+          path: Sharpmake_${{ inputs.configuration }}.binlog
+
+      - name: UnitTest ${{ inputs.framework }} - dotnet test
+        if: inputs.run_unit_tests && runner.os == 'Windows' # TODO: fix the tests on mac and linux and remove the first part of the if
+        run: dotnet test --no-build --no-restore Sharpmake.UnitTests/Sharpmake.UnitTests.csproj --framework ${{ inputs.framework }} --configuration ${{ inputs.configuration }}
+
+      - name: RegressionTest
+        if: inputs.run_regression_tests && runner.os == 'Windows'
+        run: python regression_test.py --sharpmake_exe "Sharpmake.Application\bin\${{ inputs.configuration }}\${{ inputs.framework }}\Sharpmake.Application.exe"
+
+      - name: Upload sharpmake ${{ inputs.framework }} ${{ runner.os }}-release binaries
+        if: inputs.configuration == 'release'
+        uses: actions/upload-artifact@v3
+        with:
+          name: 'Sharpmake-${{ inputs.framework }}-${{ runner.os }}-${{ github.sha }}'
+          path: Sharpmake.Application/bin/Release/${{ inputs.framework }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Requirement for GitVersion.
+      # This step ensure current commit exists on a branch.
+      # Its not the case when a workflow is triggered by a pull request coming from a fork.
+      # These commits only exists in a ref that isn't associated to any branch.
+      - name: Create branch on pull request from fork
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork
+        run: git checkout -b ${{ github.ref_name }}
+
       - name: Build Sharpmake ${{ inputs.configuration }} ${{ inputs.os }}
         shell: pwsh
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+# Sharpmake GitHub Actions release workflow
+name: release
+
+on:
+  push:
+    tags:
+      - '**'
+
+permissions:
+  contents: write
+
+jobs:
+  builds:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-2022]
+        framework: [net6.0]
+        configuration: [Release]
+    uses: ./.github/workflows/build.yml
+    with:
+      os: ${{ matrix.os }}
+      framework: ${{ matrix.framework }}
+      configuration: ${{ matrix.configuration }}
+      run_unit_tests: false
+      run_regression_tests: false
+
+  release:
+    needs: [builds]
+    runs-on: 'ubuntu-latest'
+    permissions:
+          contents: write
+
+    steps:
+      - name: 'Checkout the repo'
+        uses: actions/checkout@v3.4.0
+        with:
+          fetch-depth: 0
+
+      - name: 'Generating changelog'
+        shell: pwsh
+        run: .\Get-Changelog.ps1 ${{ github.ref_name }} > changelog.md
+
+      - name: 'Download workflow artifacts'
+        uses: actions/download-artifact@v3
+        with:
+          path: downloads
+
+      - name: 'Create release archives'
+        run: |
+          for OS in Linux macOS Windows
+          do
+              pushd ./Sharpmake-net6.0-$OS-${{ github.sha }}
+              zip -r ../Sharpmake-net6.0-$OS-${{ github.ref_name }}.zip .
+              popd
+          done
+        working-directory: downloads
+
+      - name: 'Create GitHub release'
+        uses: ncipollo/release-action@v1.12.0
+        with:
+          bodyFile: 'changelog.md'
+          artifacts: 'downloads/Sharpmake-net6.0-*-${{ github.ref_name }}.zip'

--- a/Get-Changelog.ps1
+++ b/Get-Changelog.ps1
@@ -1,0 +1,31 @@
+<#
+.SYNOPSIS
+Gets the changelog based on a commit reference.
+
+.DESCRIPTION
+Generate a changelog that contains an entry for each commits reachable from the provided commit reference until the previously tagged commit is reached.
+
+.PARAMETER commitish
+Commit-ish object name from which commits will be enumerated.
+
+.OUTPUTS
+System.String
+    Get-Changelog returns the changelog content as strings.
+#>
+param (
+    $commitish = "HEAD"
+)
+
+$rangeFirst = (git describe --abbrev=0 --tags $commitish^)
+$rangeLast = $commitish
+
+if ($LASTEXITCODE -ne 0)
+{
+    Write-Error "No previous tag found. Error $LASTEXITCODE returned by git describe."
+    return $LASTEXITCODE
+}
+
+Write-Host "Revision range: $rangeFirst..$rangeLast"
+
+Write-Output "## What's Changed"
+git log --no-merges --format=format:"- %s (%an) %h" "$rangeFirst..$rangeLast"


### PR DESCRIPTION
Workflow is run only on tags and automate the creation of the GitHub release.

An example of the created release can be for this fake release: https://github.com/sylvainfortin/Sharpmake/releases/tag/0.25.6. This release was the result of this release workflow: https://github.com/sylvainfortin/Sharpmake/actions/runs/4557636578.

EDIT: Also added a fix for the build job to fix a GitVersion issue when the workflow is triggered by a pull request coming from a fork.