### PR TITLE
Add PublishAot Option to allow NativeAot on .Net7

### DIFF
--- a/Sharpmake.Generators/VisualStudio/Csproj.Template.cs
+++ b/Sharpmake.Generators/VisualStudio/Csproj.Template.cs
@@ -111,6 +111,7 @@ namespace Sharpmake.Generators.VisualStudio
     <UseWpf>[options.UseWpf]</UseWpf>
     <UseWindowsForms>[options.UseWindowsForms]</UseWindowsForms>
     <Nullable>[options.Nullable]</Nullable>
+    <PublishAot>[options.PublishAot]</PublishAot>
   </PropertyGroup>
 ";
 

--- a/Sharpmake.Generators/VisualStudio/Csproj.cs
+++ b/Sharpmake.Generators/VisualStudio/Csproj.cs
@@ -3598,6 +3598,12 @@ namespace Sharpmake.Generators.VisualStudio
             );
 
             SelectOption
+           (
+               Options.Option(Options.CSharp.PublishAot.Enabled, () => { options["PublishAot"] = "true"; }),
+               Options.Option(Options.CSharp.PublishAot.Disabled, () => { options["PublishAot"] = RemoveLineTag; })
+           );
+
+            SelectOption
             (
                 Options.Option(Options.CSharp.UseWindowsForms.Enabled, () => { options["UseWindowsForms"] = "true"; }),
                 Options.Option(Options.CSharp.UseWindowsForms.Disabled, () => { options["UseWindowsForms"] = RemoveLineTag; })

--- a/Sharpmake/Options.CSharp.cs
+++ b/Sharpmake/Options.CSharp.cs
@@ -207,6 +207,13 @@ namespace Sharpmake
                 [Default]
                 Disabled
             }
+            public enum PublishAot
+            {
+                Enabled,
+                [Default]
+                Disabled
+            }
+
 
             public class UpdateInterval : IntOption
             {


### PR DESCRIPTION
The following is needed for NativeAOT to be enabled in a .Net 7 app 
This Pull Request adds the required option.

```
<PropertyGroup>
    <PublishAot>true</PublishAot>
</PropertyGroup>
```
https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/