### PR TITLE
Fix for a bug that is causing duplicated CLRSupport entries in C++/CL…

### DIFF
--- a/Sharpmake.Generators/VisualStudio/Vcxproj.cs
+++ b/Sharpmake.Generators/VisualStudio/Vcxproj.cs
@@ -603,7 +603,7 @@ namespace Sharpmake.Generators.VisualStudio
 
 						string clrSupportString = FileGeneratorUtilities.RemoveLineTag;
 
-                        if ( clrSupport && !clrSupportGenerated )
+                        if (clrSupport && !clrSupportGenerated)
                         {
                             var dotNetFramework = conf.Target.GetFragment<DotNetFramework>();
 
@@ -614,8 +614,10 @@ namespace Sharpmake.Generators.VisualStudio
 								clrSupportString = clrSupport.ToString().ToLower();
                             }
 							else
+							{
 							    // .Net Core requires "NetCore" instead of "true", see: https://docs.microsoft.com/en-us/dotnet/core/porting/cpp-cli
           						clrSupportString = "NetCore";
+							}
                         }
 
                         using (fileGenerator.Declare("platformName", Util.GetPlatformString(conf.Platform, conf.Project, conf.Target)))

--- a/Sharpmake.Generators/VisualStudio/Vcxproj.cs
+++ b/Sharpmake.Generators/VisualStudio/Vcxproj.cs
@@ -603,7 +603,7 @@ namespace Sharpmake.Generators.VisualStudio
 
 						string clrSupportString = FileGeneratorUtilities.RemoveLineTag;
 
-                        if (clrSupport && !clrSupportGenerated )
+                        if ( clrSupport && !clrSupportGenerated )
                         {
                             var dotNetFramework = conf.Target.GetFragment<DotNetFramework>();
 

--- a/Sharpmake.Generators/VisualStudio/Vcxproj.cs
+++ b/Sharpmake.Generators/VisualStudio/Vcxproj.cs
@@ -603,7 +603,7 @@ namespace Sharpmake.Generators.VisualStudio
 
 						string clrSupportString = FileGeneratorUtilities.RemoveLineTag;
 
-                        if (clrSupport & !clrSupportGenerated )
+                        if (clrSupport && !clrSupportGenerated )
                         {
                             var dotNetFramework = conf.Target.GetFragment<DotNetFramework>();
 

--- a/Sharpmake.Platforms/Sharpmake.CommonPlatforms/BasePlatform.Vcxproj.Template.cs
+++ b/Sharpmake.Platforms/Sharpmake.CommonPlatforms/BasePlatform.Vcxproj.Template.cs
@@ -176,7 +176,6 @@ namespace Sharpmake
     <WholeProgramOptimization>[options.WholeProgramOptimization]</WholeProgramOptimization>
     <PlatformToolset>[options.PlatformToolset]</PlatformToolset>
     <TrackFileAccess>[options.TrackFileAccess]</TrackFileAccess>
-    <CLRSupport>[options.CLRSupport]</CLRSupport>
     <WindowsTargetPlatformVersion>[options.WindowsTargetPlatformVersion]</WindowsTargetPlatformVersion>
     <SpectreMitigation>[options.SpectreMitigation]</SpectreMitigation>
     <EnableASAN>[options.EnableASAN]</EnableASAN>


### PR DESCRIPTION




This is a fix for an issue that is causing the generation of unusable project files for c++/CLR when the NET version is set to 6.0.

The element CLRSupport was being generated twice in the property group.

This has been undetected for a long time, because the duplicated entry with identical values doesn't have any influence when the project is parsed.

However, when the project is configured to generate net6.0, we are getting one entry with "NetCore" and another entry with "true". The second entry overrides the first.

As result of this, the project fails to correctly handle netcore.

 