### PR TITLE
Fix configuration of MSBuild unity/jumbo build parameters

### DIFF
--- a/Sharpmake.Platforms/Sharpmake.CommonPlatforms/BasePlatform.Vcxproj.Template.cs
+++ b/Sharpmake.Platforms/Sharpmake.CommonPlatforms/BasePlatform.Vcxproj.Template.cs
@@ -74,6 +74,9 @@ namespace Sharpmake
       <ForcedIncludeFiles>[options.ForcedIncludeFiles]</ForcedIncludeFiles>
       <ForcedUsingFiles>[options.ForcedUsingFiles]</ForcedUsingFiles>
       <SupportJustMyCode>[options.SupportJustMyCode]</SupportJustMyCode>
+      <MaxFilesInUnityFile>[options.MaxFilesPerJumboFile]</MaxFilesInUnityFile>
+      <MinFilesInUnityFile>[options.MinFilesPerJumboFile]</MinFilesInUnityFile>
+      <MinUnityFiles>[options.MinJumboFiles]</MinUnityFiles>
     </ClCompile>
 ";
 
@@ -181,9 +184,6 @@ namespace Sharpmake
     <SpectreMitigation>[options.SpectreMitigation]</SpectreMitigation>
     <EnableASAN>[options.EnableASAN]</EnableASAN>
     <EnableUnitySupport>[options.JumboBuild]</EnableUnitySupport>
-    <MaxFilesInUnityFile>[options.MaxFilesPerJumboFile]</MaxFilesInUnityFile>
-    <MinFilesInUnityFile>[options.MinFilesPerJumboFile]</MinFilesInUnityFile>
-    <MinUnityFiles>[options.MinJumboFiles]</MinUnityFiles>
   </PropertyGroup>
 ";
 

--- a/samples/JumboBuild/reference/projects/jumbobuild_vs2019_win32.vcxproj
+++ b/samples/JumboBuild/reference/projects/jumbobuild_vs2019_win32.vcxproj
@@ -27,9 +27,6 @@
     <WholeProgramOptimization>false</WholeProgramOptimization>
     <PlatformToolset>v142</PlatformToolset>
     <EnableUnitySupport>true</EnableUnitySupport>
-    <MaxFilesInUnityFile>0</MaxFilesInUnityFile>
-    <MinFilesInUnityFile>2</MinFilesInUnityFile>
-    <MinUnityFiles>1</MinUnityFiles>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
@@ -38,9 +35,6 @@
     <WholeProgramOptimization>false</WholeProgramOptimization>
     <PlatformToolset>v142</PlatformToolset>
     <EnableUnitySupport>true</EnableUnitySupport>
-    <MaxFilesInUnityFile>0</MaxFilesInUnityFile>
-    <MinFilesInUnityFile>2</MinFilesInUnityFile>
-    <MinUnityFiles>1</MinUnityFiles>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -122,6 +116,9 @@
       <AdditionalOptions>/Zc:__cplusplus</AdditionalOptions>
       <ProgramDatabaseFileName>obj\win32\debug\jumbobuild_compiler.pdb</ProgramDatabaseFileName>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <MaxFilesInUnityFile>0</MaxFilesInUnityFile>
+      <MinFilesInUnityFile>2</MinFilesInUnityFile>
+      <MinUnityFiles>1</MinUnityFiles>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -203,6 +200,9 @@
       <AdditionalOptions>/Zc:__cplusplus</AdditionalOptions>
       <ProgramDatabaseFileName>obj\win32\release\jumbobuild_compiler.pdb</ProgramDatabaseFileName>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <MaxFilesInUnityFile>0</MaxFilesInUnityFile>
+      <MinFilesInUnityFile>2</MinFilesInUnityFile>
+      <MinUnityFiles>1</MinUnityFiles>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/samples/JumboBuild/reference/projects/jumbobuild_vs2019_win64.vcxproj
+++ b/samples/JumboBuild/reference/projects/jumbobuild_vs2019_win64.vcxproj
@@ -27,9 +27,6 @@
     <WholeProgramOptimization>false</WholeProgramOptimization>
     <PlatformToolset>v142</PlatformToolset>
     <EnableUnitySupport>true</EnableUnitySupport>
-    <MaxFilesInUnityFile>0</MaxFilesInUnityFile>
-    <MinFilesInUnityFile>2</MinFilesInUnityFile>
-    <MinUnityFiles>1</MinUnityFiles>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
@@ -38,9 +35,6 @@
     <WholeProgramOptimization>false</WholeProgramOptimization>
     <PlatformToolset>v142</PlatformToolset>
     <EnableUnitySupport>true</EnableUnitySupport>
-    <MaxFilesInUnityFile>0</MaxFilesInUnityFile>
-    <MinFilesInUnityFile>2</MinFilesInUnityFile>
-    <MinUnityFiles>1</MinUnityFiles>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -122,6 +116,9 @@
       <AdditionalOptions>/Zc:__cplusplus</AdditionalOptions>
       <ProgramDatabaseFileName>obj\win64\debug\jumbobuild_compiler.pdb</ProgramDatabaseFileName>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <MaxFilesInUnityFile>0</MaxFilesInUnityFile>
+      <MinFilesInUnityFile>2</MinFilesInUnityFile>
+      <MinUnityFiles>1</MinUnityFiles>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -203,6 +200,9 @@
       <AdditionalOptions>/Zc:__cplusplus</AdditionalOptions>
       <ProgramDatabaseFileName>obj\win64\release\jumbobuild_compiler.pdb</ProgramDatabaseFileName>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <MaxFilesInUnityFile>0</MaxFilesInUnityFile>
+      <MinFilesInUnityFile>2</MinFilesInUnityFile>
+      <MinUnityFiles>1</MinUnityFiles>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
Move jumbo build configuration parameters to ClCompile block

While enabling the unity build needs to be in the PropertyGroup, the configuration parameters need to be in ClCompile in order to be picked up correctly.