### PR TITLE
Additional Flags for CustomFileBuildStepData

### DIFF
--- a/Sharpmake.Generators/VisualStudio/Vcxproj.cs
+++ b/Sharpmake.Generators/VisualStudio/Vcxproj.cs
@@ -174,7 +174,7 @@ namespace Sharpmake.Generators.VisualStudio
             foreach (var customBuildStep in buildSteps)
             {
                 var relativeBuildStep = customBuildStep.MakePathRelative(resolver, (path, commandRelative) => Util.SimplifyPath(Util.PathGetRelative(referencePath, path)));
-                if(customBuildStep.DependOnExecutable)
+                if(!customBuildStep.UseExecutableFromSystemPath)
                 {
                     relativeBuildStep.AdditionalInputs.Add(relativeBuildStep.Executable);
                 }

--- a/Sharpmake.Generators/VisualStudio/Vcxproj.cs
+++ b/Sharpmake.Generators/VisualStudio/Vcxproj.cs
@@ -174,7 +174,10 @@ namespace Sharpmake.Generators.VisualStudio
             foreach (var customBuildStep in buildSteps)
             {
                 var relativeBuildStep = customBuildStep.MakePathRelative(resolver, (path, commandRelative) => Util.SimplifyPath(Util.PathGetRelative(referencePath, path)));
-                relativeBuildStep.AdditionalInputs.Add(relativeBuildStep.Executable);
+                if(customBuildStep.DependOnExecutable)
+                {
+                    relativeBuildStep.AdditionalInputs.Add(relativeBuildStep.Executable);
+                }
                 // Build the command.
                 string command = string.Format(
                     "\"{0}\" {1}",

--- a/Sharpmake/Project.Configuration.cs
+++ b/Sharpmake/Project.Configuration.cs
@@ -2785,9 +2785,7 @@ namespace Sharpmake
                 foreach (var customFileBuildStep in CustomFileBuildSteps)
                 {
                     customFileBuildStep.Resolve(resolver);
-
                     Util.ResolvePath(Project.SourceRootPath, ref customFileBuildStep.KeyInput);
-
                     if(customFileBuildStep.ResolveExecutable)
                     {
                         Util.ResolvePath(Project.SourceRootPath, ref customFileBuildStep.Executable);

--- a/Sharpmake/Project.Configuration.cs
+++ b/Sharpmake/Project.Configuration.cs
@@ -2166,16 +2166,9 @@ namespace Sharpmake
                 /// </summary>
                 public string Executable = "";
                 /// <summary>
-                /// This passes the Executable string through a resolver
+                /// Use this to indicate the executable is in the system Path
                 /// </summary>
-                /// <remarks>
-                /// Set this to false to output Executable string without any changes
-                /// </remarks>
-                public bool ResolveExecutable = true;
-                /// <summary>
-                /// This adds the Executable to the list of AdditionalInputs to make sure its tracked
-                /// </summary>
-                public bool DependOnExecutable = true;
+                public bool UseExecutableFromSystemPath = false;
                 /// <summary>
                 /// These are the arguments to pass to the executable.
                 /// </summary>
@@ -2786,10 +2779,12 @@ namespace Sharpmake
                 {
                     customFileBuildStep.Resolve(resolver);
                     Util.ResolvePath(Project.SourceRootPath, ref customFileBuildStep.KeyInput);
-                    if(customFileBuildStep.ResolveExecutable)
+
+                    if(!customFileBuildStep.UseExecutableFromSystemPath)
                     {
                         Util.ResolvePath(Project.SourceRootPath, ref customFileBuildStep.Executable);
                     }
+
                     Util.ResolvePath(Project.SourceRootPath, ref customFileBuildStep.Output);
                     Util.ResolvePath(Project.SourceRootPath, ref customFileBuildStep.AdditionalInputs);
                 }

--- a/Sharpmake/Project.Configuration.cs
+++ b/Sharpmake/Project.Configuration.cs
@@ -2166,6 +2166,17 @@ namespace Sharpmake
                 /// </summary>
                 public string Executable = "";
                 /// <summary>
+                /// This passes the Executable string through a resolver
+                /// </summary>
+                /// <remarks>
+                /// Set this to false to output Executable string without any changes
+                /// </remarks>
+                public bool ResolveExecutable = true;
+                /// <summary>
+                /// This adds the Executable to the list of AdditionalInputs to make sure its tracked
+                /// </summary>
+                public bool DependOnExecutable = true;
+                /// <summary>
                 /// These are the arguments to pass to the executable.
                 /// </summary>
                 /// <remarks>
@@ -2774,8 +2785,13 @@ namespace Sharpmake
                 foreach (var customFileBuildStep in CustomFileBuildSteps)
                 {
                     customFileBuildStep.Resolve(resolver);
+
                     Util.ResolvePath(Project.SourceRootPath, ref customFileBuildStep.KeyInput);
-                    Util.ResolvePath(Project.SourceRootPath, ref customFileBuildStep.Executable);
+
+                    if(customFileBuildStep.ResolveExecutable)
+                    {
+                        Util.ResolvePath(Project.SourceRootPath, ref customFileBuildStep.Executable);
+                    }
                     Util.ResolvePath(Project.SourceRootPath, ref customFileBuildStep.Output);
                     Util.ResolvePath(Project.SourceRootPath, ref customFileBuildStep.AdditionalInputs);
                 }


### PR DESCRIPTION
This mainly adds two flags, `ResolveExecutable` and `DependOnExecutable`.

First one is basically to skip prefixing the `Executable` string with the project path. This allows running of programs that are in the environment but not in the project.

My use case was running a shader compiler while not adding the executable to the project.

The second flag is to skip adding the executable to the list of `AdditionalInputs`, this prevents
a warning when the executable is not found in the project.

The first flag has a workaround by overriding `MakeRelativePaths` but the second flag does not have any workaround I could find.

I'm not extensively familiar with all potential problems that might come up with these flags so any feedback on it would be appreciated. 