### PR TITLE
Added support for OutputItemType to CustomFileBuildStep.

### DIFF
--- a/Sharpmake.Generators/VisualStudio/Vcxproj.Template.cs
+++ b/Sharpmake.Generators/VisualStudio/Vcxproj.Template.cs
@@ -299,6 +299,10 @@ namespace Sharpmake.Generators.VisualStudio
 @"      <LinkObjects Condition=""'$(Configuration)|$(Platform)'=='[conf.Name]|[platformName]'"">[linkobjects]</LinkObjects>
 ";
 
+                public static string ProjectFilesCustomBuildOutputItemType =
+@"      <OutputItemType>[outputItemType]</OutputItemType>
+";
+
                 public static string ProjectFilesCustomBuildEnd =
                 @"    </CustomBuild>
 ";

--- a/Sharpmake.Generators/VisualStudio/Vcxproj.cs
+++ b/Sharpmake.Generators/VisualStudio/Vcxproj.cs
@@ -1536,19 +1536,13 @@ namespace Sharpmake.Generators.VisualStudio
                                 using (fileGenerator.Declare("command", buildStep.Commands))
                                 using (fileGenerator.Declare("inputs", buildStep.AdditionalInputs))
                                 using (fileGenerator.Declare("outputs", buildStep.Outputs))
-                                using (fileGenerator.Declare("outputItemType", buildStep.OutputItemType))
+                                using (fileGenerator.Declare("outputItemType", string.IsNullOrEmpty(buildStep.OutputItemType) ? FileGeneratorUtilities.RemoveLineTag : buildStep.OutputItemType))
                                 {
                                     fileGenerator.Write(Template.Project.ProjectFilesCustomBuildDescription);
                                     fileGenerator.Write(Template.Project.ProjectFilesCustomBuildCommand);
                                     fileGenerator.Write(Template.Project.ProjectFilesCustomBuildInputs);
                                     fileGenerator.Write(Template.Project.ProjectFilesCustomBuildOutputs);
-
-                                    // An empty OutputItemtype tag will lead to unexpected errors and there is no sensible default
-                                    // Avoid writing the tag if the user hasn't specified a value.
-                                    if (!string.IsNullOrEmpty(buildStep.OutputItemType))
-                                    {
-                                        fileGenerator.Write(Template.Project.ProjectFilesCustomBuildOutputItemType);
-                                    }
+                                    fileGenerator.Write(Template.Project.ProjectFilesCustomBuildOutputItemType);
                                 }
                             }
                         }

--- a/Sharpmake/Project.Configuration.cs
+++ b/Sharpmake/Project.Configuration.cs
@@ -2222,6 +2222,7 @@ namespace Sharpmake
                 public string Output = "";
 
                 /// <summary>
+                /// Not supported by FASTBuild.
                 /// Optional string to hint to the build system at what to treat the output from the build command as
                 /// </summary>
                 public string OutputItemType = "";

--- a/Sharpmake/Project.Configuration.cs
+++ b/Sharpmake/Project.Configuration.cs
@@ -2220,6 +2220,12 @@ namespace Sharpmake
                 /// This is what we tell the build system we're going to produce.
                 /// </summary>
                 public string Output = "";
+
+                /// <summary>
+                /// Optional string to hint to the build system at what to treat the output from the build command as
+                /// </summary>
+                public string OutputItemType = "";
+
                 /// <summary>
                 /// Not supported by FASTBuild.
                 /// Additional files that will cause a re-run of this custom build step can be be specified here.


### PR DESCRIPTION
This (optionally) allows for specifying to Vcxproj what the output files of a custom build step should be treated as. Useful in contexts where a custom build step generates other build inputs.

I have a use case where we generate C++ wrappers using swig, and want to compile them into the same project that generated them. It's significantly easier to do so if you can provide the OutputItemType field to the build step.