### PR TITLE
Added Configuration.Name and Configuration.Platform into output .csproj

### DIFF
--- a/Sharpmake.Generators/VisualStudio/Csproj.Template.cs
+++ b/Sharpmake.Generators/VisualStudio/Csproj.Template.cs
@@ -25,9 +25,9 @@ namespace Sharpmake.Generators.VisualStudio
                 public static string ProjectEnd =
 @"</Project>";
 
+
                 public static string ProjectDescription =
-@"  <PropertyGroup>
-    <Configuration Condition="" '$(Configuration)' == '' "">[options.DefaultConfiguration]</Configuration>
+@"  <Configuration Condition="" '$(Configuration)' == '' "">[options.DefaultConfiguration]</Configuration>
     <Platform Condition="" '$(Platform)' == '' "">[defaultPlatform]</Platform>
     <PlatformTarget Condition="" '$(Platform)' == '' "">[defaultPlatform]</PlatformTarget>
     <ProjectGuid>{[guid]}</ProjectGuid>
@@ -112,7 +112,6 @@ namespace Sharpmake.Generators.VisualStudio
     <UseWindowsForms>[options.UseWindowsForms]</UseWindowsForms>
     <Nullable>[options.Nullable]</Nullable>
     <PublishAot>[options.PublishAot]</PublishAot>
-  </PropertyGroup>
 ";
 
                 public const string DefaultProjectConfigurationCondition = "'$(Configuration)|$(Platform)'=='[conf.Name]|[platformName]'";
@@ -146,6 +145,21 @@ namespace Sharpmake.Generators.VisualStudio
     <CopyVsixExtensionFiles>[options.CopyVsixExtensionFiles]</CopyVsixExtensionFiles>
     <CopyVsixExtensionLocation>[options.CopyVsixExtensionLocation]</CopyVsixExtensionLocation>
     <ProduceReferenceAssembly>[options.ProduceReferenceAssembly]</ProduceReferenceAssembly>
+";
+                public static string ConfigurationsItemBegin =
+@"<Configurations>";
+                public static string ConfigurationsItemEntry =
+@"[conf.Name];";
+                public static string ConfigurationsItemEnd =
+@"</Configurations>
+";
+
+                public static string PlatformsItemBegin =
+@"<Platforms>";
+                public static string PlatformsItemEntry =
+@"[platformName];";
+                public static string PlatformsItemEnd =
+@"</Platforms>
 ";
 
                 public static string ImportProjectItemSimple =

--- a/Sharpmake.Generators/VisualStudio/Csproj.cs
+++ b/Sharpmake.Generators/VisualStudio/Csproj.cs
@@ -1321,6 +1321,7 @@ namespace Sharpmake.Generators.VisualStudio
 
             GeneratedAssemblyConfigTemplate generatedAssemblyConfigTemplate = new GeneratedAssemblyConfigTemplate(project.GeneratedAssemblyConfig, isNetCoreProjectSchema, RemoveLineTag);
 
+            Write(VsProjCommon.Template.PropertyGroupStart, writer, resolver);
             using (resolver.NewScopedParameter("project", project))
             using (resolver.NewScopedParameter("guid", projectPropertyGuid))
             using (resolver.NewScopedParameter("options", options[_projectConfigurationList[0]]))
@@ -1338,6 +1339,31 @@ namespace Sharpmake.Generators.VisualStudio
             {
                 Write(Template.Project.ProjectDescription, writer, resolver);
             }
+
+            Write(Template.Project.ConfigurationsItemBegin, writer, resolver);
+            foreach (Project.Configuration conf in _projectConfigurationList)
+            {
+                using (resolver.NewScopedParameter("conf", conf))
+                {
+                    Write(Template.Project.ConfigurationsItemEntry, writer, resolver);
+                }
+            }
+            Write(Template.Project.ConfigurationsItemEnd, writer, resolver);
+
+            Write(Template.Project.PlatformsItemBegin, writer, resolver);
+            HashSet<string> addedPlatform = new HashSet<string>();
+            foreach (Project.Configuration conf in _projectConfigurationList)
+            {
+                if (addedPlatform.Add(Util.GetPlatformString(conf.Platform, conf.Project, conf.Target)))
+                {
+                    using (resolver.NewScopedParameter("platformName", Util.GetPlatformString(conf.Platform, conf.Project, conf.Target)))
+                    {
+                        Write(Template.Project.PlatformsItemEntry, writer, resolver);
+                    }
+                }
+            }
+            Write(Template.Project.PlatformsItemEnd, writer, resolver);
+            Write(VsProjCommon.Template.PropertyGroupEnd, writer, resolver);
 
             if (!string.IsNullOrEmpty(project.ApplicationIcon))
             {


### PR DESCRIPTION
Issue: #359

This is my attempt at fixing this issue. 

Configuration Names and Platforms are now generated inside the .csproj description and now show up as proper configurations in visual studio  .

Changes include:
- Modification to ProjectDescription in Csproj.Template to no longer contain PropertyGroup being/end tags
- Added ConfigurationsItemBegin ConfigurationsItemEntry ConfigurationsItemEnd properties for generating configuration names
- Added PlatformsItemBegin PlatformsItemEntry PlatformsItemEnd properties for generating platforms for project configurations
- Modification to how ProjectDescription is generated when Generate() is called. 
First it writes a PropertyGroupStart, writes ProjectDescription then writes ConfigurationItemBeing/Entry/End items and PlatformsItemBegin/Entry/End items and finally writes a PropertyGroupEnd
