### PR TITLE
Add major roll forward to Sharpmake.Application

### DIFF
--- a/Sharpmake.Application/Sharpmake.Application.csproj
+++ b/Sharpmake.Application/Sharpmake.Application.csproj
@@ -7,6 +7,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ServerGarbageCollection>true</ServerGarbageCollection>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fix for samples running on GitHub Mac runners. Latest image contains only .NET 7 and 8 SDKs.