### PR TITLE
Bump actions/upload-artifact and actions/download-artifact from 3 to 4

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v4.1.4
 
       - name: Download sharpmake ${{ matrix.framework }} ${{ runner.os }}-release binaries
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: 'Sharpmake-${{ matrix.framework }}-${{ runner.os }}-${{ github.sha }}'
           path: Sharpmake.Application/bin/Release/${{ matrix.framework }}
@@ -93,7 +93,7 @@ jobs:
           "VS_VERSION_SUFFIX=vs2022" >> $env:GITHUB_ENV
 
       - name: Download sharpmake ${{ matrix.framework }} ${{ runner.os }}-release binaries
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: 'Sharpmake-${{ matrix.framework }}-${{ runner.os }}-${{ github.sha }}'
           path: Sharpmake.Application/bin/Release/${{ matrix.framework }}
@@ -108,7 +108,7 @@ jobs:
 
       - name: Store MSBuild binary logs
         if: ${{ failure() && runner.os == 'Windows' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sharpmake-sample-msbuild-logs-${{ matrix.name }}-${{ matrix.framework }}-${{ runner.os }}-${{ github.sha }}-${{ matrix.configuration }}
           path: samples/**/*.binlog

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Store MSBuild binary logs
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sharpmake-msbuild-logs-${{ inputs.framework }}-${{ runner.os }}-${{ github.sha }}-${{ inputs.configuration }}
           path: Sharpmake_${{ inputs.configuration }}.binlog
@@ -67,7 +67,7 @@ jobs:
 
       - name: Upload sharpmake ${{ inputs.framework }} ${{ runner.os }}-release binaries
         if: inputs.configuration == 'release'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: 'Sharpmake-${{ inputs.framework }}-${{ runner.os }}-${{ github.sha }}'
           path: Sharpmake.Application/bin/Release/${{ inputs.framework }}


### PR DESCRIPTION
#320 and #321 needs to be merged in the same PR since they are depending on each other.

This PR will removed all warnings about Node.js 16 in Actions workflows.