### PR TITLE
Temporary XCodeProjects sample removal from GitHub Actions

### DIFF
--- a/SamplesDef.json
+++ b/SamplesDef.json
@@ -402,7 +402,7 @@
         },
         {
             "Name": "XCodeProjects",
-            "CIs": [ "github", "gitlab" ],
+            "CIs": [ "gitlab" ],
             "OSs": [ "macos" ],
             "Frameworks": [ "net6.0" ],
             "Configurations": [ "debug", "release" ],


### PR DESCRIPTION
Starting with mac image version 20240722.3, XCodeProjects are crashing during link. To be investigated.