### PR TITLE
Sharpmake.Options.Vc.Compiler.UseStandardConformingPreprocessor support

### DIFF
--- a/Sharpmake.Generators/FastBuild/Bff.Template.cs
+++ b/Sharpmake.Generators/FastBuild/Bff.Template.cs
@@ -355,6 +355,7 @@ Compiler( '[fastBuildMasmCompilerName]' )
             + ' [cmdLineOptions.IgnoreStandardIncludePath]'
             + ' [cmdLineOptions.GeneratePreprocessedFile]'
             + ' [cmdLineOptions.KeepComments]'
+            + ' [cmdLineOptions.UseStandardConformingPreprocessor]'
             + ' [cmdLineOptions.StringPooling]'
             + ' [cmdLineOptions.MinimalRebuild]'
             + ' [cmdLineOptions.ExceptionHandling]'

--- a/Sharpmake.Generators/VisualStudio/ProjectOptionsGenerator.cs
+++ b/Sharpmake.Generators/VisualStudio/ProjectOptionsGenerator.cs
@@ -700,9 +700,21 @@ namespace Sharpmake.Generators.VisualStudio
             //    Enable                                  /Zc:preprocessor
             context.SelectOption
             (
-            Options.Option(Options.Vc.Compiler.UseStandardConformingPreprocessor.Default, () => { }),
-            Options.Option(Options.Vc.Compiler.UseStandardConformingPreprocessor.Disable, () => { context.Configuration.AdditionalCompilerOptions.Add("/Zc:preprocessor-"); }),
-            Options.Option(Options.Vc.Compiler.UseStandardConformingPreprocessor.Enable, () => { context.Configuration.AdditionalCompilerOptions.Add("/Zc:preprocessor"); })
+            Options.Option(Options.Vc.Compiler.UseStandardConformingPreprocessor.Default, () =>
+            {
+                context.Options["UseStandardConformingPreprocessor"] = FileGeneratorUtilities.RemoveLineTag;
+                context.CommandLineOptions["UseStandardConformingPreprocessor"] = FileGeneratorUtilities.RemoveLineTag;
+            }),
+            Options.Option(Options.Vc.Compiler.UseStandardConformingPreprocessor.Disable, () =>
+            {
+                context.Options["UseStandardConformingPreprocessor"] = "false";
+                context.CommandLineOptions["UseStandardConformingPreprocessor"] = "/Zc:preprocessor-";
+            }),
+            Options.Option(Options.Vc.Compiler.UseStandardConformingPreprocessor.Enable, () =>
+            {
+                context.Options["UseStandardConformingPreprocessor"] = "true";
+                context.CommandLineOptions["UseStandardConformingPreprocessor"] = "/Zc:preprocessor";
+            })
             );
 
             //Options.Vc.Compiler.StringPooling.

--- a/Sharpmake.Generators/VisualStudio/ProjectOptionsGenerator.cs
+++ b/Sharpmake.Generators/VisualStudio/ProjectOptionsGenerator.cs
@@ -695,6 +695,16 @@ namespace Sharpmake.Generators.VisualStudio
             Options.Option(Options.Vc.Compiler.KeepComment.Enable, () => { context.Options["KeepComments"] = "true"; context.CommandLineOptions["KeepComments"] = "/C"; })
             );
 
+            //Options.Vc.Compiler.UseStandardConformingPreprocessor.    See: https://learn.microsoft.com/en-us/cpp/build/reference/zc-preprocessor?view=msvc-170
+            //    Disable                                 /Zc:preprocessor-
+            //    Enable                                  /Zc:preprocessor
+            context.SelectOption
+            (
+            Options.Option(Options.Vc.Compiler.UseStandardConformingPreprocessor.Default, () => { }),
+            Options.Option(Options.Vc.Compiler.UseStandardConformingPreprocessor.Disable, () => { context.Configuration.AdditionalCompilerOptions.Add("/Zc:preprocessor-"); }),
+            Options.Option(Options.Vc.Compiler.UseStandardConformingPreprocessor.Enable, () => { context.Configuration.AdditionalCompilerOptions.Add("/Zc:preprocessor"); })
+            );
+
             //Options.Vc.Compiler.StringPooling.
             //    Disable                                 StringPooling="false"
             //    Enable                                  StringPooling="true"                            /GF

--- a/Sharpmake.Platforms/Sharpmake.CommonPlatforms/BasePlatform.Vcxproj.Template.cs
+++ b/Sharpmake.Platforms/Sharpmake.CommonPlatforms/BasePlatform.Vcxproj.Template.cs
@@ -35,6 +35,7 @@ namespace Sharpmake
       <PreprocessToFile>[options.GeneratePreprocessedFile]</PreprocessToFile>
       <PreprocessSuppressLineNumbers>[options.PreprocessSuppressLineNumbers]</PreprocessSuppressLineNumbers>
       <PreprocessKeepComments>[options.KeepComments]</PreprocessKeepComments>
+      <UseStandardPreprocessor>[options.UseStandardConformingPreprocessor]</UseStandardPreprocessor>
       <StringPooling>[options.StringPooling]</StringPooling>
       <MinimalRebuild>[options.MinimalRebuild]</MinimalRebuild>
       <ExceptionHandling>[options.ExceptionHandling]</ExceptionHandling>

--- a/Sharpmake/Options.Vc.cs
+++ b/Sharpmake/Options.Vc.cs
@@ -680,6 +680,17 @@ namespace Sharpmake
                 }
 
                 /// <summary>
+                /// Enables a token-based preprocessor that conforms to C99 and C++11 and later standards.
+                /// </summary>
+                public enum UseStandardConformingPreprocessor
+                {
+                    [Default]
+                    Default,
+                    Disable,
+                    Enable
+                }
+
+                /// <summary>
                 /// Enables the compiler to create a single read-only copy of identical strings in the program image and in memory during execution, resulting in smaller programs, an optimization called string pooling. /O1, /O2, and /ZI  automatically set /GF option.
                 /// </summary>
                 public enum StringPooling


### PR DESCRIPTION
Added compiler option "Sharpmake.Options.Vc.Compiler.UseStandardConformingPreprocessor" to set the additional option "/Zc:preprocessor"

https://learn.microsoft.com/en-us/cpp/build/reference/zc-preprocessor?view=msvc-170