### PR TITLE
[Vcxproj] Support explicit path to NuGet .targets, and clean up existing packages.config if no longer needed

### DIFF
--- a/Sharpmake.Generators/VisualStudio/Vcxproj.Template.cs
+++ b/Sharpmake.Generators/VisualStudio/Vcxproj.Template.cs
@@ -160,6 +160,15 @@ namespace Sharpmake.Generators.VisualStudio
 @"    <Error Condition=""!Exists('$(SolutionDir)\packages\[packageName].[packageVersion]\build\[packageName].targets') and !Exists('$(SolutionDir)\packages\[packageName].[packageVersion]\build\native\[packageName].targets')"" Text=""$([[System.String]]::Format('$(ErrorText)', '$(SolutionDir)\packages\[packageName].[packageVersion]\build\native\[packageName].targets'))"" />
 ";
 
+                public static string ProjectTargetsNugetReferenceImportExplicitPath =
+@"    <Import Project=""$(SolutionDir)\packages\[packageName].[packageVersion]\[packageTargets]"" Condition=""Exists('$(SolutionDir)\packages\[packageName].[packageVersion]\[packageTargets]')"" />
+";
+                
+                public static string ProjectTargetsNugetReferenceErrorExplicitPath =
+@"    <Error Condition=""!Exists('$(SolutionDir)\packages\[packageName].[packageVersion]\[packageTargets]')"" Text=""$([[System.String]]::Format('$(ErrorText)', '$(SolutionDir)\packages\[packageName].[packageVersion]\[packageTargets]'))"" />
+";
+
+
                 public static string ProjectTargetsEnd =
 @"  </ImportGroup>
 ";

--- a/Sharpmake.Generators/VisualStudio/Vcxproj.cs
+++ b/Sharpmake.Generators/VisualStudio/Vcxproj.cs
@@ -623,13 +623,12 @@ namespace Sharpmake.Generators.VisualStudio
                 GenerateBffFilesSection(context, fileGenerator);
 
             // Generate and add reference to packages.config file for project
-            if (firstConf.ReferencesByNuGetPackage.Count > 0)
+            if (firstConf.ReferencesByNuGetPackage.Count > 0 && hasFastBuildConfig)
             {
-                if (hasFastBuildConfig)
-                {
-                    throw new NotImplementedException("Nuget packages in c++ is not currently supported by FastBuild");
-                }
-
+                throw new NotImplementedException("Nuget packages in c++ is not currently supported by FastBuild");
+            }
+            else
+            {
                 var packagesConfig = new PackagesConfig();
                 packagesConfig.Generate(context.Builder, firstConf, "native", context.ProjectDirectory, generatedFiles, skipFiles);
                 if (packagesConfig.IsGenerated)

--- a/Sharpmake.Generators/VisualStudio/Vcxproj.cs
+++ b/Sharpmake.Generators/VisualStudio/Vcxproj.cs
@@ -684,7 +684,8 @@ namespace Sharpmake.Generators.VisualStudio
             // add imports to nuget packages
             foreach (var package in firstConf.ReferencesByNuGetPackage)
             {
-                fileGenerator.WriteVerbatim(package.Resolve(fileGenerator.Resolver, Template.Project.ProjectTargetsNugetReferenceImport));
+                string customTemplate = string.IsNullOrEmpty(package.TargetsPath) ? Template.Project.ProjectTargetsNugetReferenceImport : Template.Project.ProjectTargetsNugetReferenceImportExplicitPath;
+                fileGenerator.WriteVerbatim(package.Resolve(fileGenerator.Resolver, customTemplate));
             }
             fileGenerator.Write(Template.Project.ProjectTargetsEnd);
 
@@ -707,7 +708,8 @@ namespace Sharpmake.Generators.VisualStudio
 
                 foreach (var package in firstConf.ReferencesByNuGetPackage)
                 {
-                    fileGenerator.WriteVerbatim(package.Resolve(fileGenerator.Resolver, Template.Project.ProjectTargetsNugetReferenceError));
+                    string customTemplate = string.IsNullOrEmpty(package.TargetsPath) ? Template.Project.ProjectTargetsNugetReferenceError : Template.Project.ProjectTargetsNugetReferenceErrorExplicitPath;
+                    fileGenerator.WriteVerbatim(package.Resolve(fileGenerator.Resolver, customTemplate));
                 }
 
                 fileGenerator.Write(Template.Project.ProjectCustomTargetsEnd);

--- a/Sharpmake/PackageReferences.cs
+++ b/Sharpmake/PackageReferences.cs
@@ -18,18 +18,18 @@ namespace Sharpmake
         [DebuggerDisplay("{Name} {Version}")]
         public class PackageReference : IResolverHelper, IComparable<PackageReference>
         {
-            internal PackageReference(string name, string version, string dotNetHint, AssetsDependency privateAssets, string targetsPath, string referenceType)
+            internal PackageReference(string name, string version, string dotNetHint, AssetsDependency privateAssets, string referenceType, string targetsPath)
             {
                 Name = name;
                 Version = version;
                 DotNetHint = dotNetHint;
                 PrivateAssets = privateAssets;
-                TargetsPath = targetsPath;
                 ReferenceType = referenceType;
+                TargetsPath = targetsPath;
             }
 
             internal PackageReference(string name, string version, string dotNetHint, AssetsDependency privateAssets, string targetsPath)
-                : this(name, version, dotNetHint, privateAssets, targetsPath, null)
+                : this(name, version, dotNetHint, privateAssets, null, targetsPath)
             {
             }
 
@@ -144,13 +144,13 @@ namespace Sharpmake
 
         private readonly UniqueList<PackageReference> _packageReferences = new UniqueList<PackageReference>();
 
-        public void Add(string packageName, string version, string dotNetHint = null, AssetsDependency privateAssets = DefaultPrivateAssets, string targetsPath = null, string referenceType = null)
+        public void Add(string packageName, string version, string dotNetHint = null, AssetsDependency privateAssets = DefaultPrivateAssets, string referenceType = null, string targetsPath = null)
         {
             // check package unicity
             var existingPackage = _packageReferences.FirstOrDefault(pr => pr.Name == packageName);
             if (existingPackage == null)
             {
-                _packageReferences.Add(new PackageReference(packageName, version, null, privateAssets, targetsPath, referenceType));
+                _packageReferences.Add(new PackageReference(packageName, version, null, privateAssets, referenceType, targetsPath));
                 return;
             }
 

--- a/Sharpmake/PackageReferences.cs
+++ b/Sharpmake/PackageReferences.cs
@@ -202,6 +202,5 @@ namespace Sharpmake
 
         internal const AssetsDependency DefaultPrivateAssets =
             AssetsDependency.ContentFiles | AssetsDependency.Analyzers | AssetsDependency.Build;
-        internal static readonly string[] DefaultTargetPaths = new string[]{ @"build\[packageName].targets", @"build\native\[packageName].targets" };
     }
 }

--- a/Sharpmake/PackageReferences.cs
+++ b/Sharpmake/PackageReferences.cs
@@ -18,23 +18,25 @@ namespace Sharpmake
         [DebuggerDisplay("{Name} {Version}")]
         public class PackageReference : IResolverHelper, IComparable<PackageReference>
         {
-            internal PackageReference(string name, string version, string dotNetHint, AssetsDependency privateAssets, string referenceType)
+            internal PackageReference(string name, string version, string dotNetHint, AssetsDependency privateAssets, string targetsPath, string referenceType)
             {
                 Name = name;
                 Version = version;
                 DotNetHint = dotNetHint;
                 PrivateAssets = privateAssets;
+                TargetsPath = targetsPath;
                 ReferenceType = referenceType;
             }
 
-            internal PackageReference(string name, string version, string dotNetHint, AssetsDependency privateAssets)
-                : this(name, version, dotNetHint, privateAssets, null)
+            internal PackageReference(string name, string version, string dotNetHint, AssetsDependency privateAssets, string targetsPath)
+                : this(name, version, dotNetHint, privateAssets, targetsPath, null)
             {
             }
 
             public string Name { get; internal set; }
             public string Version { get; internal set; }
             public string DotNetHint { get; internal set; }
+            public string TargetsPath { get; internal set; }
             public string ReferenceType { get; internal set; }
 
             public AssetsDependency PrivateAssets { get; internal set; }
@@ -60,6 +62,7 @@ namespace Sharpmake
             {
                 using (resolver.NewScopedParameter("packageName", Name))
                 using (resolver.NewScopedParameter("packageVersion", Version))
+                using (resolver.NewScopedParameter("packageTargets", TargetsPath))
                 {
                     return resolver.Resolve(customTemplate);
                 }
@@ -141,13 +144,13 @@ namespace Sharpmake
 
         private readonly UniqueList<PackageReference> _packageReferences = new UniqueList<PackageReference>();
 
-        public void Add(string packageName, string version, string dotNetHint = null, AssetsDependency privateAssets = DefaultPrivateAssets, string referenceType = null)
+        public void Add(string packageName, string version, string dotNetHint = null, AssetsDependency privateAssets = DefaultPrivateAssets, string targetsPath = null, string referenceType = null)
         {
             // check package unicity
             var existingPackage = _packageReferences.FirstOrDefault(pr => pr.Name == packageName);
             if (existingPackage == null)
             {
-                _packageReferences.Add(new PackageReference(packageName, version, null, privateAssets, referenceType));
+                _packageReferences.Add(new PackageReference(packageName, version, null, privateAssets, targetsPath, referenceType));
                 return;
             }
 
@@ -199,5 +202,6 @@ namespace Sharpmake
 
         internal const AssetsDependency DefaultPrivateAssets =
             AssetsDependency.ContentFiles | AssetsDependency.Analyzers | AssetsDependency.Build;
+        internal static readonly string[] DefaultTargetPaths = new string[]{ @"build\[packageName].targets", @"build\native\[packageName].targets" };
     }
 }


### PR DESCRIPTION
**Context**
While attempting to add support for [Microsoft.GameInput](https://www.nuget.org/packages/Microsoft.GameInput) to my project, I noticed the path to its `.targets`-file was different to the two paths that were supported by Sharpmake as is. I was unable to find any examples of the same issue being solved previously, or clear ways to alter the path, so I figured adding a way to explicitly define that path could be useful.

Additionally, I noticed the generated `packages.config` would remain after regenerating the solution having removed all packages from the project.

**Description**
The change adds a field to supply an explicit `.targets`-path, which then allows a simplified XML-string to be used to resolve the final `.vcxproj` line for the import and error. If an explicit path is not defined, the behaviour with the two possible paths is used so previous sharpmake-files still function.

Usage:
```c#
conf.ReferencesByNuGetPackage.Add(
	"Microsoft.GameInput",
	"0.2303.22621.3038",
	targetsPath: @"build\native\targets\[packageName].targets"
);
```

Also changes `Vcxproj.GenerateImpl()` to run the `PackagesConfig` generator even if there are no NuGet packages defined, to allow it to clean up existing files that are no longer meant to exist, in case the project is not generated from a clean slate.

**Additional info**
All regression tests have run fine as far as I can tell, both using the script and via Visual Studio. I couldn't actually locate any specific tests related to vcxproj files though, so I'm uncertain how well covered the changes I've made here are.