### PR TITLE
[Vcxproj] Improve NuGet handling in packages.config mode & add necessary logic for package reference mode

### DIFF
--- a/SamplesDef.json
+++ b/SamplesDef.json
@@ -57,7 +57,6 @@
             "Commands":
             [
                 "./RunSharpmake.ps1 -workingDirectory {testFolder} -sharpmakeFile \"CPPForcePackageReference.sharpmake.cs\" -framework {framework}",
-                "./RunProcess.ps1 -exeToRun msbuild -workingDirectory \"{testFolder}/projects\" -arguments \"-t:restore CPPForcePackageReference_{VsVersionSuffix}_win64.sln\"",
                 "./Compile.ps1 -slnOrPrjFile \"CPPForcePackageReference_{VsVersionSuffix}_win64.sln\" -configuration {configuration} -platform \"x64\" -WorkingDirectory \"{testFolder}/projects\" -VsVersion {os} -compiler MsBuild",
                 "&'./{testFolder}/projects/output/win64/{configuration}/cppforcepackagereference.exe'"
             ]

--- a/SamplesDef.json
+++ b/SamplesDef.json
@@ -48,6 +48,21 @@
             ]
         },
         {
+            "Name": "CPPForcePackageReference",
+            "CIs": [ "github", "gitlab" ],
+            "OSs": [ "windows-2022" ],
+            "Frameworks": [ "net6.0" ],
+            "Configurations": [ "debug", "release" ],
+            "TestFolder": "samples/CPPForcePackageReference",
+            "Commands":
+            [
+                "./RunSharpmake.ps1 -workingDirectory {testFolder} -sharpmakeFile \"CPPForcePackageReference.sharpmake.cs\" -framework {framework}",
+                "./RunProcess.ps1 -exeToRun msbuild -workingDirectory \"{testFolder}/projects\" -arguments \"-t:restore CPPForcePackageReference_{VsVersionSuffix}_win64.sln\"",
+                "./Compile.ps1 -slnOrPrjFile \"CPPForcePackageReference_{VsVersionSuffix}_win64.sln\" -configuration {configuration} -platform \"x64\" -WorkingDirectory \"{testFolder}/projects\" -VsVersion {os} -compiler MsBuild",
+                "&'./{testFolder}/projects/output/win64/{configuration}/cppforcepackagereference.exe'"
+            ]
+        },
+        {
             "Name": "CSharpHelloWorld_old_Frameworks",
             "CIs": [ "github", "gitlab" ],
             "OSs": [ "windows-2019" ],

--- a/Sharpmake.Generators/VisualStudio/Vcxproj.Template.cs
+++ b/Sharpmake.Generators/VisualStudio/Vcxproj.Template.cs
@@ -163,7 +163,7 @@ namespace Sharpmake.Generators.VisualStudio
                 // possible file extension: .targets and .props
                 public static string ProjectNugetReferenceImport =
 @"    <Import Project=""$(SolutionDir)\packages\[packageName].[packageVersion]\build\native\[packageName].[fileExtension]"" Condition=""Exists('$(SolutionDir)\packages\[packageName].[packageVersion]\build\native\[packageName].[fileExtension]')"" />
-    <Import Project=""$(SolutionDir)\packages\[packageName].[packageVersion]\build\[packageName].[fileExtension]"" Condition=""Exists('$(SolutionDir)\packages\[packageName].[packageVersion]\build\[packageName].[fileExtension]')"" />
+    <Import Project=""$(SolutionDir)\packages\[packageName].[packageVersion]\build\[packageName].[fileExtension]"" Condition=""!Exists('$(SolutionDir)\packages\[packageName].[packageVersion]\build\native\[packageName].[fileExtension]') and Exists('$(SolutionDir)\packages\[packageName].[packageVersion]\build\[packageName].[fileExtension]')"" />
 ";
 
                 public static string ProjectNugetReferenceError =

--- a/Sharpmake.Generators/VisualStudio/Vcxproj.Template.cs
+++ b/Sharpmake.Generators/VisualStudio/Vcxproj.Template.cs
@@ -160,12 +160,12 @@ namespace Sharpmake.Generators.VisualStudio
 ";
 
                 // Support both regular and native package types, whichever happens to exist
-                public static string ProjectTargetsNugetReferenceImport =
-@"    <Import Project=""$(SolutionDir)\packages\[packageName].[packageVersion]\build\[packageName].targets"" Condition=""Exists('$(SolutionDir)\packages\[packageName].[packageVersion]\build\[packageName].targets')"" />
-    <Import Project=""$(SolutionDir)\packages\[packageName].[packageVersion]\build\native\[packageName].targets"" Condition=""Exists('$(SolutionDir)\packages\[packageName].[packageVersion]\build\native\[packageName].targets')"" />
+                public static string ProjectNugetReferenceTargetsImport =
+@"    <Import Project=""$(SolutionDir)\packages\[packageName].[packageVersion]\build\native\[packageName].targets"" Condition=""Exists('$(SolutionDir)\packages\[packageName].[packageVersion]\build\native\[packageName].targets')"" />
+    <Import Project=""$(SolutionDir)\packages\[packageName].[packageVersion]\build\[packageName].targets"" Condition=""Exists('$(SolutionDir)\packages\[packageName].[packageVersion]\build\[packageName].targets')"" />
 ";
 
-                public static string ProjectTargetsNugetReferenceError =
+                public static string ProjectNugetReferenceTargetsError =
 @"    <Error Condition=""!Exists('$(SolutionDir)\packages\[packageName].[packageVersion]\build\[packageName].targets') and !Exists('$(SolutionDir)\packages\[packageName].[packageVersion]\build\native\[packageName].targets')"" Text=""$([[System.String]]::Format('$(ErrorText)', '$(SolutionDir)\packages\[packageName].[packageVersion]\build\native\[packageName].targets'))"" />
 ";
 
@@ -174,7 +174,7 @@ namespace Sharpmake.Generators.VisualStudio
 ";
 
                 public static string ProjectCustomTargetsBegin =
-@"  <Target Name=""name"" BeforeTargets=""PrepareForBuild"">
+@"  <Target Name=""[targetName]"" BeforeTargets=""[beforeTargets]"">
 ";
 
                 public static string ProjectCustomTargetsEnd =

--- a/Sharpmake.Generators/VisualStudio/Vcxproj.Template.cs
+++ b/Sharpmake.Generators/VisualStudio/Vcxproj.Template.cs
@@ -160,13 +160,14 @@ namespace Sharpmake.Generators.VisualStudio
 ";
 
                 // Support both regular and native package types, whichever happens to exist
-                public static string ProjectNugetReferenceTargetsImport =
-@"    <Import Project=""$(SolutionDir)\packages\[packageName].[packageVersion]\build\native\[packageName].targets"" Condition=""Exists('$(SolutionDir)\packages\[packageName].[packageVersion]\build\native\[packageName].targets')"" />
-    <Import Project=""$(SolutionDir)\packages\[packageName].[packageVersion]\build\[packageName].targets"" Condition=""Exists('$(SolutionDir)\packages\[packageName].[packageVersion]\build\[packageName].targets')"" />
+                // possible file extension: .targets and .props
+                public static string ProjectNugetReferenceImport =
+@"    <Import Project=""$(SolutionDir)\packages\[packageName].[packageVersion]\build\native\[packageName].[fileExtension]"" Condition=""Exists('$(SolutionDir)\packages\[packageName].[packageVersion]\build\native\[packageName].[fileExtension]')"" />
+    <Import Project=""$(SolutionDir)\packages\[packageName].[packageVersion]\build\[packageName].[fileExtension]"" Condition=""Exists('$(SolutionDir)\packages\[packageName].[packageVersion]\build\[packageName].[fileExtension]')"" />
 ";
 
-                public static string ProjectNugetReferenceTargetsError =
-@"    <Error Condition=""!Exists('$(SolutionDir)\packages\[packageName].[packageVersion]\build\[packageName].targets') and !Exists('$(SolutionDir)\packages\[packageName].[packageVersion]\build\native\[packageName].targets')"" Text=""$([[System.String]]::Format('$(ErrorText)', '$(SolutionDir)\packages\[packageName].[packageVersion]\build\native\[packageName].targets'))"" />
+                public static string ProjectNugetReferenceError =
+@"    <Error Condition=""!Exists('$(SolutionDir)\packages\[packageName].[packageVersion]\build\[packageName].[fileExtension]') and !Exists('$(SolutionDir)\packages\[packageName].[packageVersion]\build\native\[packageName].[fileExtension]')"" Text=""$([[System.String]]::Format('$(ErrorText)', '$(SolutionDir)\packages\[packageName].[packageVersion]\build\native\[packageName].[fileExtension]'))"" />
 ";
 
                 public static string ProjectTargetsEnd =

--- a/Sharpmake.Generators/VisualStudio/Vcxproj.cs
+++ b/Sharpmake.Generators/VisualStudio/Vcxproj.cs
@@ -372,17 +372,6 @@ namespace Sharpmake.Generators.VisualStudio
 
             var firstConf = context.ProjectConfigurations.First();
 
-            // add .props files imported from nuget packages
-            // it must be at the top of project files.
-            // why? https://github.com/NuGet/Home/issues/10125#issuecomment-721400495
-            foreach (var package in firstConf.ReferencesByNuGetPackage)
-            {
-                using (fileGenerator.Declare("fileExtension", "props"))
-                {
-                    fileGenerator.WriteVerbatim(package.Resolve(fileGenerator.Resolver, Template.Project.ProjectNugetReferenceImport));
-                }
-            }
-
 
             VsProjCommon.WriteCustomProperties(context.Project.CustomProperties, fileGenerator);
 
@@ -757,10 +746,6 @@ namespace Sharpmake.Generators.VisualStudio
                 foreach (var package in firstConf.ReferencesByNuGetPackage)
                 {
                     using (fileGenerator.Declare("fileExtension", "targets"))
-                    {
-                        fileGenerator.WriteVerbatim(package.Resolve(fileGenerator.Resolver, Template.Project.ProjectNugetReferenceError));
-                    }
-                    using (fileGenerator.Declare("fileExtension", "props"))
                     {
                         fileGenerator.WriteVerbatim(package.Resolve(fileGenerator.Resolver, Template.Project.ProjectNugetReferenceError));
                     }

--- a/Sharpmake.Generators/VisualStudio/Vcxproj.cs
+++ b/Sharpmake.Generators/VisualStudio/Vcxproj.cs
@@ -716,7 +716,7 @@ namespace Sharpmake.Generators.VisualStudio
             // add imports to nuget packages
             foreach (var package in firstConf.ReferencesByNuGetPackage)
             {
-                fileGenerator.WriteVerbatim(package.Resolve(fileGenerator.Resolver, Template.Project.ProjectTargetsNugetReferenceImport));
+                fileGenerator.WriteVerbatim(package.Resolve(fileGenerator.Resolver, Template.Project.ProjectNugetReferenceTargetsImport));
             }
             fileGenerator.Write(Template.Project.ProjectTargetsEnd);
 
@@ -739,7 +739,7 @@ namespace Sharpmake.Generators.VisualStudio
 
                 foreach (var package in firstConf.ReferencesByNuGetPackage)
                 {
-                    fileGenerator.WriteVerbatim(package.Resolve(fileGenerator.Resolver, Template.Project.ProjectTargetsNugetReferenceError));
+                    fileGenerator.WriteVerbatim(package.Resolve(fileGenerator.Resolver, Template.Project.ProjectNugetReferenceTargetsError));
                 }
 
                 fileGenerator.Write(Template.Project.ProjectCustomTargetsEnd);

--- a/Sharpmake.Generators/VisualStudio/Vcxproj.cs
+++ b/Sharpmake.Generators/VisualStudio/Vcxproj.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Sharpmake.Generators.FastBuild;
-using static Sharpmake.DebugBreaks;
 
 namespace Sharpmake.Generators.VisualStudio
 {

--- a/Sharpmake.Generators/VisualStudio/Vcxproj.cs
+++ b/Sharpmake.Generators/VisualStudio/Vcxproj.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Sharpmake.Generators.FastBuild;
+using static Sharpmake.DebugBreaks;
 
 namespace Sharpmake.Generators.VisualStudio
 {
@@ -372,6 +373,7 @@ namespace Sharpmake.Generators.VisualStudio
 
             var firstConf = context.ProjectConfigurations.First();
 
+            NuGet nuGet = new NuGet(context.Project.NuGetReferenceType);
 
             VsProjCommon.WriteCustomProperties(context.Project.CustomProperties, fileGenerator);
 
@@ -645,7 +647,7 @@ namespace Sharpmake.Generators.VisualStudio
             else if (hasFastBuildConfig)
                 GenerateBffFilesSection(context, fileGenerator);
 
-            // Generate and add reference to packages.config file for project
+            // Generate and add reference to packages.config file for project (if using packages.config mode)
             if (firstConf.ReferencesByNuGetPackage.Count > 0)
             {
                 if (hasFastBuildConfig)
@@ -653,15 +655,7 @@ namespace Sharpmake.Generators.VisualStudio
                     throw new NotImplementedException("Nuget packages in c++ is not currently supported by FastBuild");
                 }
 
-                var packagesConfig = new PackagesConfig();
-                packagesConfig.Generate(context.Builder, firstConf, "native", context.ProjectDirectory, generatedFiles, skipFiles);
-                if (packagesConfig.IsGenerated)
-                {
-                    fileGenerator.Write(Template.Project.ProjectFilesBegin);
-                    using (fileGenerator.Declare("file", new ProjectFile(context, Util.SimplifyPath(packagesConfig.PackagesConfigPath))))
-                        fileGenerator.Write(Template.Project.ProjectFilesNone);
-                    fileGenerator.Write(Template.Project.ProjectFilesEnd);
-                }
+                nuGet.TryGeneratePackagesConfig(firstConf, context, fileGenerator, generatedFiles, skipFiles);
             }
 
             // Import platform makefiles.
@@ -669,90 +663,73 @@ namespace Sharpmake.Generators.VisualStudio
                 platform.GenerateMakefileConfigurationVcxproj(context, fileGenerator);
 
             // .targets files
-            fileGenerator.Write(Template.Project.ProjectTargetsBegin);
-            if (context.Project.ContainsASM)
             {
-                fileGenerator.Write(Template.Project.ProjectMasmTargetsItem);
-            }
-            if (context.Project.ContainsNASM)
-            {
-                if (context.Project.NasmExePath.Length == 0)
+                fileGenerator.Write(Template.Project.ProjectTargetsBegin);
+                if (context.Project.ContainsASM)
                 {
-                    throw new ArgumentNullException("NasmExePath not set and needed for NASM assembly files.");
+                    fileGenerator.Write(Template.Project.ProjectMasmTargetsItem);
                 }
-                using (fileGenerator.Declare("importedNasmTargetsFile", context.Project.NasmTargetsFile))
+                if (context.Project.ContainsNASM)
                 {
-                    fileGenerator.Write(Template.Project.ProjectNasmTargetsItem);
-                }
-            }
-
-            foreach (string targetsFiles in context.Project.CustomTargetsFiles)
-            {
-                string capitalizedFile = Project.GetCapitalizedFile(targetsFiles) ?? targetsFiles;
-
-                string relativeFile = Util.PathGetRelative(context.ProjectDirectoryCapitalized, capitalizedFile);
-                using (fileGenerator.Declare("importedTargetsFile", relativeFile))
-                {
-                    fileGenerator.Write(Template.Project.ProjectTargetsItem);
-                }
-            }
-
-            // configuration .targets files
-            foreach (Project.Configuration conf in context.ProjectConfigurations)
-            {
-                using (fileGenerator.Declare("platformName", Util.GetToolchainPlatformString(conf.Platform, conf.Project, conf.Target)))
-                using (fileGenerator.Declare("conf", conf))
-                {
-                    foreach (string targetsFile in conf.CustomTargetsFiles)
+                    if (context.Project.NasmExePath.Length == 0)
                     {
-                        string capitalizedFile = Project.GetCapitalizedFile(targetsFile) ?? targetsFile;
+                        throw new ArgumentNullException("NasmExePath not set and needed for NASM assembly files.");
+                    }
+                    using (fileGenerator.Declare("importedNasmTargetsFile", context.Project.NasmTargetsFile))
+                    {
+                        fileGenerator.Write(Template.Project.ProjectNasmTargetsItem);
+                    }
+                }
 
-                        string relativeFile = Util.PathGetRelative(context.ProjectDirectoryCapitalized, capitalizedFile);
-                        using (fileGenerator.Declare("importedTargetsFile", relativeFile))
+                foreach (string targetsFiles in context.Project.CustomTargetsFiles)
+                {
+                    string capitalizedFile = Project.GetCapitalizedFile(targetsFiles) ?? targetsFiles;
+
+                    string relativeFile = Util.PathGetRelative(context.ProjectDirectoryCapitalized, capitalizedFile);
+                    using (fileGenerator.Declare("importedTargetsFile", relativeFile))
+                    {
+                        fileGenerator.Write(Template.Project.ProjectTargetsItem);
+                    }
+                }
+
+                // configuration .targets files
+                foreach (Project.Configuration conf in context.ProjectConfigurations)
+                {
+                    using (fileGenerator.Declare("platformName", Util.GetToolchainPlatformString(conf.Platform, conf.Project, conf.Target)))
+                    using (fileGenerator.Declare("conf", conf))
+                    {
+                        foreach (string targetsFile in conf.CustomTargetsFiles)
                         {
-                            fileGenerator.Write(Template.Project.ProjectConfigurationImportedTargets);
+                            string capitalizedFile = Project.GetCapitalizedFile(targetsFile) ?? targetsFile;
+
+                            string relativeFile = Util.PathGetRelative(context.ProjectDirectoryCapitalized, capitalizedFile);
+                            using (fileGenerator.Declare("importedTargetsFile", relativeFile))
+                            {
+                                fileGenerator.Write(Template.Project.ProjectConfigurationImportedTargets);
+                            }
                         }
                     }
                 }
-            }
 
-            // add .targets files imported from nuget packages
-            foreach (var package in firstConf.ReferencesByNuGetPackage)
-            {
-                using (fileGenerator.Declare("fileExtension", "targets"))
-                {
-                    fileGenerator.WriteVerbatim(package.Resolve(fileGenerator.Resolver, Template.Project.ProjectNugetReferenceImport));
-                }
-            }
-            fileGenerator.Write(Template.Project.ProjectTargetsEnd);
+                // add .targets files imported from nuget packages (if using packages.config mode)
+                nuGet.TryGenerateImport(NuGet.ImportFileExtension.Targets, firstConf, fileGenerator);
 
-            // add error checks for nuget package targets files
+                fileGenerator.Write(Template.Project.ProjectTargetsEnd);
+            } // .targets files done
+
+            // add error checks for nuget package targets files (if using packages.config mode)
             if (firstConf.ReferencesByNuGetPackage.Count > 0)
             {
-                using (fileGenerator.Declare("targetName", "EnsureNuGetPackageBuildImports"))
-                using (fileGenerator.Declare("beforeTargets", "PrepareForBuild"))
-                {
-                    fileGenerator.Write(Template.Project.ProjectCustomTargetsBegin);
-                }
-
-                fileGenerator.Write(Template.Project.PropertyGroupStart);
-                using (fileGenerator.Declare("custompropertyname", "ErrorText"))
-                using (fileGenerator.Declare("custompropertyvalue", "This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}."))
-                {
-                    fileGenerator.Write(Template.Project.CustomProperty);
-                }
-                fileGenerator.Write(Template.Project.PropertyGroupEnd);
-
-                foreach (var package in firstConf.ReferencesByNuGetPackage)
-                {
-                    using (fileGenerator.Declare("fileExtension", "targets"))
-                    {
-                        fileGenerator.WriteVerbatim(package.Resolve(fileGenerator.Resolver, Template.Project.ProjectNugetReferenceError));
-                    }
-                }
-
-                fileGenerator.Write(Template.Project.ProjectCustomTargetsEnd);
+                nuGet.TryGenerateImportErrorCheck(NuGet.ImportFileExtension.Targets, firstConf, fileGenerator);
             }
+
+
+            // Instead trying add nuget package reference in modern way (if using PackageReference mode)
+            if (firstConf.ReferencesByNuGetPackage.Count > 0)
+            {
+                nuGet.TryGeneratePackageReferences(firstConf, fileGenerator);
+            }
+
 
             // in case we are using fast build we do not want to write most dependencies
             // in the vcxproj because they are handled internally in the bff.
@@ -2046,6 +2023,141 @@ namespace Sharpmake.Generators.VisualStudio
                     skipFiles.Add(copyDependenciesFileInfo.FullName);
             }
         }
+
+
+        private class NuGet
+        {
+            public enum ImportFileExtension
+            {
+                Targets,
+                Props,
+            }
+
+            private static string ToString(ImportFileExtension fileExt) => fileExt switch
+            {
+                ImportFileExtension.Targets => "targets",
+                ImportFileExtension.Props   => "props",
+                _ => throw new ArgumentOutOfRangeException(nameof(fileExt), fileExt, null)
+            };
+
+            private Project.NuGetPackageMode NuGetReferenceType { get; set; }
+
+            // VersionDefault fallback to packages,config (for now)
+            private bool shouldUsePackagesConfig => NuGetReferenceType == Project.NuGetPackageMode.PackageConfig
+                                                 || (NuGetReferenceType == Project.NuGetPackageMode.VersionDefault);
+
+            public NuGet(Project.NuGetPackageMode mode = Project.NuGetPackageMode.VersionDefault)
+            {
+                if (NuGetReferenceType == Project.NuGetPackageMode.ProjectJson)
+                {
+                    throw new NotImplementedException($"NuGet Package reference by {NuGetReferenceType.ToString()} files is not implemented for vcxproj");
+                }
+
+                NuGetReferenceType = mode;
+            }
+
+            #region For packages.config
+
+            // packages.config: old default implementation for vcxproj
+            // (yet it's still a broken implementation as it only handles .target files, and
+            //  TODO: 1. .props files are not considered (and they must be put at the beginning of vcxproj)
+            //  TODO: 2. other than build/ and build/native folder, irregular paths to .targets and .props files could not be access correctly
+            // )
+            public void TryGeneratePackagesConfig(
+                Project.Configuration firstConfiguration,
+                IVcxprojGenerationContext context,
+                IFileGenerator fileGenerator,
+                IList<string> generatedFiles,
+                IList<string> skipFiles)
+            {
+                if (!shouldUsePackagesConfig)
+                    return;
+
+                var packagesConfig = new PackagesConfig();
+                packagesConfig.Generate(context.Builder, firstConfiguration, "native", context.ProjectDirectory, generatedFiles, skipFiles);
+                if (packagesConfig.IsGenerated)
+                {
+                    fileGenerator.Write(Template.Project.ProjectFilesBegin);
+                    using (fileGenerator.Declare("file", new ProjectFile(context, Util.SimplifyPath(packagesConfig.PackagesConfigPath))))
+                        fileGenerator.Write(Template.Project.ProjectFilesNone);
+                    fileGenerator.Write(Template.Project.ProjectFilesEnd);
+                }
+            }
+
+            public void TryGenerateImport(ImportFileExtension fileExtension, Project.Configuration firstConfiguration, IFileGenerator fileGenerator)
+            {
+                if (!shouldUsePackagesConfig)
+                    return;
+
+                foreach (var package in firstConfiguration.ReferencesByNuGetPackage)
+                {
+                    using (fileGenerator.Declare("fileExtension", ToString(fileExtension)))
+                    {
+                        fileGenerator.WriteVerbatim(package.Resolve(fileGenerator.Resolver, Template.Project.ProjectNugetReferenceImport));
+                    }
+                }
+            }
+
+            public void TryGenerateImportErrorCheck(ImportFileExtension fileExtension, Project.Configuration firstConfiguration, IFileGenerator fileGenerator)
+            {
+                if (!shouldUsePackagesConfig)
+                    return;
+
+                using (fileGenerator.Declare("targetName", "EnsureNuGetPackageBuildImports"))
+                using (fileGenerator.Declare("beforeTargets", "PrepareForBuild"))
+                {
+                    fileGenerator.Write(Template.Project.ProjectCustomTargetsBegin);
+                }
+
+                fileGenerator.Write(Template.Project.PropertyGroupStart);
+                using (fileGenerator.Declare("custompropertyname", "ErrorText"))
+                using (fileGenerator.Declare("custompropertyvalue", "This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}."))
+                {
+                    fileGenerator.Write(Template.Project.CustomProperty);
+                }
+                fileGenerator.Write(Template.Project.PropertyGroupEnd);
+
+                foreach (var package in firstConfiguration.ReferencesByNuGetPackage)
+                {
+                    using (fileGenerator.Declare("fileExtension", ToString(fileExtension)))
+                    {
+                        fileGenerator.WriteVerbatim(package.Resolve(fileGenerator.Resolver, Template.Project.ProjectNugetReferenceError));
+                    }
+                }
+
+                fileGenerator.Write(Template.Project.ProjectCustomTargetsEnd);
+            }
+            #endregion
+
+            #region For PackageReference
+            public void TryGeneratePackageReferences( 
+                Project.Configuration firstConfiguration, 
+                IFileGenerator fileGenerator)
+            {
+                var devenv = firstConfiguration.Target.GetFragment<DevEnv>();
+
+                // package reference: by hacking in vs2017+
+                // only if manually chosen (for now)
+                if (NuGetReferenceType == Project.NuGetPackageMode.PackageReference && devenv >= DevEnv.vs2017)
+                {
+                    if (devenv < DevEnv.vs2017)
+                        throw new Error("Package references are not supported on Visual Studio versions below vs2017");
+
+                    var resolver = new Resolver();
+                    fileGenerator.Write(Template.Project.ItemGroupBegin);
+                    foreach (var package in firstConfiguration.ReferencesByNuGetPackage)
+                    {
+                        fileGenerator.WriteVerbatim(package.Resolve(resolver));
+                    }
+                    fileGenerator.Write(Template.Project.ItemGroupEnd);
+
+                    // TODO: remove packages.config file if existed ?
+                }
+            }
+            #endregion
+
+        }
+
 
         public class ProjectFile
         {

--- a/Sharpmake/Project.cs
+++ b/Sharpmake/Project.cs
@@ -84,6 +84,14 @@ namespace Sharpmake
             set { SetProperty(ref _rootPath, value); }
         }
 
+
+        private NuGetPackageMode _nuGetReferenceType = NuGetPackageMode.VersionDefault;   // Determines the type of NuGet references generated for this project
+        public NuGetPackageMode NuGetReferenceType
+        {
+            get { return _nuGetReferenceType; }
+            set { SetProperty(ref _nuGetReferenceType, value); }
+        }
+
         private DependenciesCopyLocalTypes _dependenciesCopyLocal = DependenciesCopyLocalTypes.Default; //used primarily for the .Net Framework
         public DependenciesCopyLocalTypes DependenciesCopyLocal
         {
@@ -2394,9 +2402,6 @@ namespace Sharpmake
         public bool ConfigurationSpecificEvents = false;
 
         public GeneratedAssemblyConfig GeneratedAssemblyConfig = new GeneratedAssemblyConfig();
-
-        // Determines the type of NuGet references generated for this project
-        public NuGetPackageMode NuGetReferenceType = NuGetPackageMode.VersionDefault;
 
         public Options.CSharp.RunPostBuildEvent RunPostBuildEvent = Options.CSharp.RunPostBuildEvent.OnBuildSuccess;
 

--- a/samples/CPPForcePackageReference/CPPForcePackageReference.sharpmake.cs
+++ b/samples/CPPForcePackageReference/CPPForcePackageReference.sharpmake.cs
@@ -1,0 +1,79 @@
+using System.IO;
+using Sharpmake;
+
+namespace CPPForcePackageReference
+{
+    [Generate]
+    public class CPPForcePackageReference : Project
+    {
+        public CPPForcePackageReference()
+        {
+            Name = "CPPForcePackageReference";
+
+            AddTargets(new Target(
+                    Platform.win64,
+                    DevEnv.vs2022,
+                    Optimization.Debug | Optimization.Release
+            ));
+
+            SourceRootPath     = @"[project.SharpmakeCsPath]\codebase";
+            NuGetReferenceType = NuGetPackageMode.PackageReference; // explicitly specify PackageReference for this cpp project
+        }
+
+        [Configure]
+        public void ConfigureAll(Configuration conf, Target target)
+        {
+            conf.ProjectFileName = "[project.Name]_[target.DevEnv]_[target.Platform]";
+            conf.ProjectPath = @"[project.SharpmakeCsPath]\projects";
+            conf.Options.Add(Options.Vc.Compiler.Exceptions.Enable);
+
+            // copy Directory.Build.props that forces the Nuget PackageReference feature for cpp project to be enabled
+            string directoryBuildPropsName = "Directory.Build.props";
+            DirectoryInfo srcPath  = new DirectoryInfo(@$"{SharpmakeCsPath}\codebase\"); // SourceRootPath + ..
+            DirectoryInfo destPath = new DirectoryInfo(@$"{SharpmakeCsPath}\projects\"); // conf.ProjectPath + ..
+            if (!destPath.Exists)
+            {
+                destPath.Create();
+            }
+            Util.ForceCopy(Path.Combine(srcPath.FullName, directoryBuildPropsName), Path.Combine(destPath.FullName, directoryBuildPropsName));
+
+            // cpp source code uses nlohmann.json, we specify another nuget package that depends on nlohmann.json
+            // to test if nuget could correctly restore the dependency
+            conf.ReferencesByNuGetPackage.Add("SiddiqSoft.sip2json", "1.17.3");
+        }
+    }
+
+    [Generate]
+    public class CPPForcePackageReferenceSolution : Sharpmake.Solution
+    {
+        public CPPForcePackageReferenceSolution()
+        {
+            Name = "CPPForcePackageReference";
+
+            AddTargets(new Target(
+                    Platform.win64,
+                    DevEnv.vs2022,
+                    Optimization.Debug | Optimization.Release
+            ));
+        }
+
+        [Configure()]
+        public void ConfigureAll(Configuration conf, Target target)
+        {
+            conf.SolutionFileName = "[solution.Name]_[target.DevEnv]_[target.Platform]";
+            conf.SolutionPath = @"[solution.SharpmakeCsPath]\projects";
+            conf.AddProject<CPPForcePackageReference>(target);
+
+        }
+    }
+
+    public static class Main
+    {
+        [Sharpmake.Main]
+        public static void SharpmakeMain(Sharpmake.Arguments arguments)
+        {
+            KitsRootPaths.SetUseKitsRootForDevEnv(DevEnv.vs2022, KitsRootEnum.KitsRoot10, Options.Vc.General.WindowsTargetPlatformVersion.v10_0_19041_0);
+            arguments.Generate<CPPForcePackageReferenceSolution>();
+        }
+    }
+}

--- a/samples/CPPForcePackageReference/codebase/Directory.Build.props
+++ b/samples/CPPForcePackageReference/codebase/Directory.Build.props
@@ -1,0 +1,18 @@
+<Project DefaultTargets="Build" ToolsVersion="17.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- Enable PackageReference support in C++ projects, see https://github.com/NuGet/NuGet.Client/pull/3145#issuecomment-888769783 -->
+  <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.vcxproj'">
+    <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == ''">native,Version=v0.0</NuGetTargetMoniker>
+  </PropertyGroup>
+  
+  <ItemGroup Condition="'$(MSBuildProjectExtension)' == '.vcxproj'">
+    <ProjectCapability Include="PackageReferences" />
+  </ItemGroup>
+
+  <PropertyGroup>
+
+    <MSBuildProjectExtensionsPath>obj\$(MSBuildProjectName)\</MSBuildProjectExtensionsPath>
+    
+  </PropertyGroup>
+
+</Project>

--- a/samples/CPPForcePackageReference/codebase/main.cpp
+++ b/samples/CPPForcePackageReference/codebase/main.cpp
@@ -1,0 +1,37 @@
+#include <iostream>
+#include <nlohmann/json.hpp>
+using json = nlohmann::json;
+
+
+int main(int, char**)
+{
+    std::cout << "I was built in "
+
+#if _DEBUG
+        "Debug"
+#endif
+
+#if NDEBUG
+        "Release"
+#endif
+
+#if _WIN64
+        " x64"
+#else
+        " x86"
+#endif
+
+        << std::endl;
+
+
+    json j = {
+        {"happy", true},
+        {"pi", 3.141},
+    };
+
+    for (auto& element : j) {
+        std::cout << element << '\n';
+    }
+
+    return 0;
+}

--- a/samples/CPPForcePackageReference/reference/projects/cppforcepackagereference_vs2022_win64.sln
+++ b/samples/CPPForcePackageReference/reference/projects/cppforcepackagereference_vs2022_win64.sln
@@ -1,0 +1,19 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CPPForcePackageReference", "cppforcepackagereference_vs2022_win64.vcxproj", "{9E635693-40E9-C1A2-3B1D-447B25D6293E}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{9E635693-40E9-C1A2-3B1D-447B25D6293E}.Debug|x64.ActiveCfg = Debug|x64
+		{9E635693-40E9-C1A2-3B1D-447B25D6293E}.Debug|x64.Build.0 = Debug|x64
+		{9E635693-40E9-C1A2-3B1D-447B25D6293E}.Release|x64.ActiveCfg = Release|x64
+		{9E635693-40E9-C1A2-3B1D-447B25D6293E}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/samples/CPPForcePackageReference/reference/projects/cppforcepackagereference_vs2022_win64.vcxproj
+++ b/samples/CPPForcePackageReference/reference/projects/cppforcepackagereference_vs2022_win64.vcxproj
@@ -1,0 +1,237 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="17.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{9E635693-40E9-C1A2-3B1D-447B25D6293E}</ProjectGuid>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <RootNamespace>CPPForcePackageReference</RootNamespace>
+    <ProjectName>CPPForcePackageReference</ProjectName>
+  </PropertyGroup>
+  <PropertyGroup Label="Globals">
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>MultiByte</CharacterSet>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <CharacterSet>MultiByte</CharacterSet>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <TargetName>cppforcepackagereference</TargetName>
+    <OutDir>output\win64\debug\</OutDir>
+    <IntDir>obj\win64\debug\</IntDir>
+    <TargetExt>.exe</TargetExt>
+    <GenerateManifest>true</GenerateManifest>
+    <LinkIncremental>false</LinkIncremental>
+    <OutputFile>output\win64\debug\cppforcepackagereference.exe</OutputFile>
+    <IgnoreImportLibrary>false</IgnoreImportLibrary>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <TargetName>cppforcepackagereference</TargetName>
+    <OutDir>output\win64\release\</OutDir>
+    <IntDir>obj\win64\release\</IntDir>
+    <TargetExt>.exe</TargetExt>
+    <GenerateManifest>true</GenerateManifest>
+    <LinkIncremental>false</LinkIncremental>
+    <OutputFile>output\win64\release\cppforcepackagereference.exe</OutputFile>
+    <IgnoreImportLibrary>false</IgnoreImportLibrary>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN64;_CONSOLE;_DEBUG;%(PreprocessorDefinitions);$(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <TreatWarningAsError>false</TreatWarningAsError>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <UseUnicodeForAssemblerListing>false</UseUnicodeForAssemblerListing>
+      <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FavorSizeOrSpeed>Neither</FavorSizeOrSpeed>
+      <OmitFramePointers>false</OmitFramePointers>
+      <EnableFiberSafeOptimizations>false</EnableFiberSafeOptimizations>
+      <WholeProgramOptimization>false</WholeProgramOptimization>
+      <UndefineAllPreprocessorDefinitions>false</UndefineAllPreprocessorDefinitions>
+      <IgnoreStandardIncludePath>false</IgnoreStandardIncludePath>
+      <PreprocessToFile>false</PreprocessToFile>
+      <PreprocessSuppressLineNumbers>false</PreprocessSuppressLineNumbers>
+      <PreprocessKeepComments>false</PreprocessKeepComments>
+      <StringPooling>true</StringPooling>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <SmallerTypeCheck>false</SmallerTypeCheck>
+      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <StructMemberAlignment>Default</StructMemberAlignment>
+      <BufferSecurityCheck>true</BufferSecurityCheck>
+      <FunctionLevelLinking>false</FunctionLevelLinking>
+      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <FloatingPointExceptions>false</FloatingPointExceptions>
+      <DisableLanguageExtensions>false</DisableLanguageExtensions>
+      <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
+      <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <OpenMPSupport>false</OpenMPSupport>
+      <ExpandAttributedSource>false</ExpandAttributedSource>
+      <AssemblerOutput>NoListing</AssemblerOutput>
+      <GenerateXMLDocumentationFiles>false</GenerateXMLDocumentationFiles>
+      <BrowseInformation>false</BrowseInformation>
+      <CallingConvention>Cdecl</CallingConvention>
+      <CompileAs>Default</CompileAs>
+      <AdditionalOptions>/Zc:__cplusplus</AdditionalOptions>
+      <ProgramDatabaseFileName>obj\win64\debug\cppforcepackagereference_compiler.pdb</ProgramDatabaseFileName>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <OutputFile>output\win64\debug\cppforcepackagereference.exe</OutputFile>
+      <ShowProgress>NotSet</ShowProgress>
+      <ProgramDatabaseFile>output\win64\debug\cppforcepackagereference.pdb</ProgramDatabaseFile>
+      <GenerateMapFile>true</GenerateMapFile>
+      <MapExports>false</MapExports>
+      <SwapRunFromCD>false</SwapRunFromCD>
+      <SwapRunFromNET>false</SwapRunFromNET>
+      <Driver>NotSet</Driver>
+      <OptimizeReferences>false</OptimizeReferences>
+      <EnableCOMDATFolding>false</EnableCOMDATFolding>
+      <ProfileGuidedDatabase>
+      </ProfileGuidedDatabase>
+      <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
+      <IgnoreEmbeddedIDL>false</IgnoreEmbeddedIDL>
+      <TypeLibraryResourceID>1</TypeLibraryResourceID>
+      <NoEntryPoint>false</NoEntryPoint>
+      <SetChecksum>false</SetChecksum>
+      <TurnOffAssemblyGeneration>false</TurnOffAssemblyGeneration>
+      <TargetMachine>MachineX64</TargetMachine>
+      <Profile>false</Profile>
+      <CLRImageType>Default</CLRImageType>
+      <LinkErrorReporting>PromptImmediately</LinkErrorReporting>
+      <AdditionalDependencies>;%(AdditionalDependencies)</AdditionalDependencies>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+      <IgnoreSpecificDefaultLibraries></IgnoreSpecificDefaultLibraries>
+      <LargeAddressAware>true</LargeAddressAware>
+      <MapFileName>output\win64\debug\cppforcepackagereference.map</MapFileName>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>Full</Optimization>
+      <PreprocessorDefinitions>NDEBUG;WIN64;_CONSOLE;%(PreprocessorDefinitions);$(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <TreatWarningAsError>false</TreatWarningAsError>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <UseUnicodeForAssemblerListing>false</UseUnicodeForAssemblerListing>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <OmitFramePointers>false</OmitFramePointers>
+      <EnableFiberSafeOptimizations>false</EnableFiberSafeOptimizations>
+      <WholeProgramOptimization>false</WholeProgramOptimization>
+      <UndefineAllPreprocessorDefinitions>false</UndefineAllPreprocessorDefinitions>
+      <IgnoreStandardIncludePath>false</IgnoreStandardIncludePath>
+      <PreprocessToFile>false</PreprocessToFile>
+      <PreprocessSuppressLineNumbers>false</PreprocessSuppressLineNumbers>
+      <PreprocessKeepComments>false</PreprocessKeepComments>
+      <StringPooling>true</StringPooling>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <SmallerTypeCheck>false</SmallerTypeCheck>
+      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <StructMemberAlignment>Default</StructMemberAlignment>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <FloatingPointExceptions>false</FloatingPointExceptions>
+      <DisableLanguageExtensions>false</DisableLanguageExtensions>
+      <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
+      <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <OpenMPSupport>false</OpenMPSupport>
+      <ExpandAttributedSource>false</ExpandAttributedSource>
+      <AssemblerOutput>NoListing</AssemblerOutput>
+      <GenerateXMLDocumentationFiles>false</GenerateXMLDocumentationFiles>
+      <BrowseInformation>false</BrowseInformation>
+      <CallingConvention>Cdecl</CallingConvention>
+      <CompileAs>Default</CompileAs>
+      <AdditionalOptions>/Zc:__cplusplus</AdditionalOptions>
+      <ProgramDatabaseFileName>obj\win64\release\cppforcepackagereference_compiler.pdb</ProgramDatabaseFileName>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <OutputFile>output\win64\release\cppforcepackagereference.exe</OutputFile>
+      <ShowProgress>NotSet</ShowProgress>
+      <ProgramDatabaseFile>output\win64\release\cppforcepackagereference.pdb</ProgramDatabaseFile>
+      <GenerateMapFile>true</GenerateMapFile>
+      <MapExports>false</MapExports>
+      <SwapRunFromCD>false</SwapRunFromCD>
+      <SwapRunFromNET>false</SwapRunFromNET>
+      <Driver>NotSet</Driver>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <ProfileGuidedDatabase>
+      </ProfileGuidedDatabase>
+      <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
+      <IgnoreEmbeddedIDL>false</IgnoreEmbeddedIDL>
+      <TypeLibraryResourceID>1</TypeLibraryResourceID>
+      <NoEntryPoint>false</NoEntryPoint>
+      <SetChecksum>false</SetChecksum>
+      <TurnOffAssemblyGeneration>false</TurnOffAssemblyGeneration>
+      <TargetMachine>MachineX64</TargetMachine>
+      <Profile>false</Profile>
+      <CLRImageType>Default</CLRImageType>
+      <LinkErrorReporting>PromptImmediately</LinkErrorReporting>
+      <AdditionalDependencies>;%(AdditionalDependencies)</AdditionalDependencies>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+      <IgnoreSpecificDefaultLibraries></IgnoreSpecificDefaultLibraries>
+      <LargeAddressAware>true</LargeAddressAware>
+      <MapFileName>output\win64\release\cppforcepackagereference.map</MapFileName>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\codebase\main.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+  <ItemGroup>
+    <PackageReference Include="SiddiqSoft.sip2json" Version="1.17.3" />
+  </ItemGroup>
+</Project>

--- a/samples/CPPForcePackageReference/reference/projects/cppforcepackagereference_vs2022_win64.vcxproj.filters
+++ b/samples/CPPForcePackageReference/reference/projects/cppforcepackagereference_vs2022_win64.vcxproj.filters
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="17.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="..\codebase\main.cpp" />
+  </ItemGroup>
+</Project>

--- a/samples/PackageReferences/reference/projects/cpppackagereferences/cpppackagereferences.vs2019.v4_7_2.vcxproj
+++ b/samples/PackageReferences/reference/projects/cpppackagereferences/cpppackagereferences.vs2019.v4_7_2.vcxproj
@@ -233,10 +233,10 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\gtest-vc140-static-64.targets" Condition="Exists('$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\gtest-vc140-static-64.targets')" />
+    <Import Project="$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\gtest-vc140-static-64.targets" Condition="!Exists('$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\native\gtest-vc140-static-64.targets') and Exists('$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\gtest-vc140-static-64.targets')" />
     <Import Project="$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\native\gtest-vc140-static-64.targets" Condition="Exists('$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\native\gtest-vc140-static-64.targets')" />
   </ImportGroup>
-  <Target Name="name" BeforeTargets="PrepareForBuild">
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
   <PropertyGroup>
     <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
   </PropertyGroup>

--- a/samples/PackageReferences/reference/projects/cpppackagereferences/cpppackagereferences.vs2019.v4_7_2.vcxproj
+++ b/samples/PackageReferences/reference/projects/cpppackagereferences/cpppackagereferences.vs2019.v4_7_2.vcxproj
@@ -233,8 +233,8 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\gtest-vc140-static-64.targets" Condition="!Exists('$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\native\gtest-vc140-static-64.targets') and Exists('$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\gtest-vc140-static-64.targets')" />
     <Import Project="$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\native\gtest-vc140-static-64.targets" Condition="Exists('$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\native\gtest-vc140-static-64.targets')" />
+    <Import Project="$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\gtest-vc140-static-64.targets" Condition="!Exists('$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\native\gtest-vc140-static-64.targets') and Exists('$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\gtest-vc140-static-64.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
   <PropertyGroup>

--- a/samples/PackageReferences/reference/projects/cpppackagereferences/cpppackagereferences.vs2022.v4_7_2.vcxproj
+++ b/samples/PackageReferences/reference/projects/cpppackagereferences/cpppackagereferences.vs2022.v4_7_2.vcxproj
@@ -233,10 +233,10 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\gtest-vc140-static-64.targets" Condition="Exists('$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\gtest-vc140-static-64.targets')" />
+    <Import Project="$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\gtest-vc140-static-64.targets" Condition="!Exists('$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\native\gtest-vc140-static-64.targets') and Exists('$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\gtest-vc140-static-64.targets')" />
     <Import Project="$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\native\gtest-vc140-static-64.targets" Condition="Exists('$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\native\gtest-vc140-static-64.targets')" />
   </ImportGroup>
-  <Target Name="name" BeforeTargets="PrepareForBuild">
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
   <PropertyGroup>
     <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
   </PropertyGroup>

--- a/samples/PackageReferences/reference/projects/cpppackagereferences/cpppackagereferences.vs2022.v4_7_2.vcxproj
+++ b/samples/PackageReferences/reference/projects/cpppackagereferences/cpppackagereferences.vs2022.v4_7_2.vcxproj
@@ -233,8 +233,8 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\gtest-vc140-static-64.targets" Condition="!Exists('$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\native\gtest-vc140-static-64.targets') and Exists('$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\gtest-vc140-static-64.targets')" />
     <Import Project="$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\native\gtest-vc140-static-64.targets" Condition="Exists('$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\native\gtest-vc140-static-64.targets')" />
+    <Import Project="$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\gtest-vc140-static-64.targets" Condition="!Exists('$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\native\gtest-vc140-static-64.targets') and Exists('$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\gtest-vc140-static-64.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
   <PropertyGroup>

--- a/samples/Properties/launchSettings.json
+++ b/samples/Properties/launchSettings.json
@@ -18,6 +18,12 @@
       "commandLineArgs": "/sources(@'CLRTest.sharpmake.cs')",
       "workingDirectory": "$(ProjectDir)\\CPPCLI"
     },
+    "Sample (CPPForcePackageReference)": {
+        "commandName": "Executable",
+        "executablePath": "$(ProjectDir)\\..\\Sharpmake.Application\\bin\\$(Configuration)\\$(TargetFramework)\\Sharpmake.Application.exe",
+        "commandLineArgs": "/sources(@'CPPForcePackageReference.sharpmake.cs')",
+        "workingDirectory": "$(ProjectDir)\\CPPForcePackageReference"
+    },
     "Sample (CSharpHelloWorld)": {
       "commandName": "Executable",
       "executablePath": "$(ProjectDir)\\..\\Sharpmake.Application\\bin\\$(Configuration)\\$(TargetFramework)\\Sharpmake.Application.exe",


### PR DESCRIPTION
### 1. Improve `.targets` import logic when using NuGet packages.config mode
Old Behaviour: `/build/native/*.targets` and `/build/*.targets` are both imported.

Problem: in common, `/build/native/*.targets` for C++ project is firstly chosen if presented, old logic will make  `/build/*.targets` also be imported, and in before of `/build/native/*.targets`, causing troubles. 
e.g. Microsoft.WindowsAppSDK

Current Behaviour:  `/build/native/*.targets` import is made before `/build/*.targets` , it will check if `/build/native/*.targets` 
 is not presented, then do the `/build/*.targets` import.

---

### 2. Add support codes for NuGet package reference mode in `.vcxproj`
The current NuGet support for C++ project is incomplete.
- `.props` file import is not supported.
- lack methods to determine if `.targets` and `.props` files are initially presented in order to generate correct error check.
- Irregular path to `.targets` and `.props` files are not supported.
    - Like the problem discussed below (yet providing a configurable custom path is not a good solution) 
    #390 
- All other downsides of packages.config mode (cannot restore dependencies, etc.)

[here](https://developercommunity.visualstudio.com/t/use-packagereference-in-vcxproj/351636) and https://github.com/NuGet/NuGet.Client/pull/3145 have shown the way to force package reference mode for `.vcxproj`.
To achieve this in Sharpmake, it requires
1. A custom configuration of `Directory.Build.props`
2. `<PackageReference>` element generation support inside Sharpmake

This PR contains the 2. part.

I haven't figure out the best way to automatically handle 1., but since `Directory.Build.props` is originally a thing that users manually add to their projects, so it should be no harm to let them also add that [custom configuration](https://gist.github.com/zyzyz/6b129624033c4d9f0a2f5a7c314dde4b) manually (for now?)

P.S. the default NuGet mode for C++ project still keeps as packages.config.