### PR TITLE
Fixed Bff file error when AndroidAPILevel not set

### DIFF
--- a/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Android/AndroidAgdePlatform.cs
+++ b/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Android/AndroidAgdePlatform.cs
@@ -322,6 +322,10 @@ namespace Sharpmake
                     AndroidBuildTargets androidBuildtarget = Android.Util.GetAndroidBuildTarget(conf);
                     cmdLineOptions["ClangCompilerTarget"] = $"-target {Android.Util.GetTargetTripleWithVersionSuffix(androidBuildtarget, androidApiNum)}";
                 }
+                else
+                {
+                    cmdLineOptions["ClangCompilerTarget"] = RemoveLineTag;
+                }
 
                 context.SelectOptionWithFallback
                 (


### PR DESCRIPTION
ClangCompilerTarget is never set when the AndroidAPILevel is set to default, thus causing the Bff scripts to break.

This was the error it throws.

```
...
|| Error: Cannot find path 'ClangCompilerTarget' in parameter path 'cmdLineOptions.ClangCompilerTarget' in '
||     .CompilerExtraOptions   = ''
||             // System options
||             // -------------------------
||             + ' [cmdLineOptions.ClangDiagnosticsFormat]'
||             + ' [cmdLineOptions.ClangCompilerTarget]'
||
...
```

Edit: I'm experimenting with AGDE as I go and I ran into this immediately trying to get FastBuild going. If the `-target` flag is actually required (which I will find out) then this isn't a good fix at all.