### PR TITLE
Fixed DebugSolution not building when using Android Targets

### DIFF
--- a/Sharpmake/DebugProjectGenerator.cs
+++ b/Sharpmake/DebugProjectGenerator.cs
@@ -40,16 +40,19 @@ namespace Sharpmake
 
                 string sharpmakeDllPath;
                 string sharpmakeGeneratorDllPath;
-                GetSharpmakeLocalDlls(out sharpmakeDllPath, out sharpmakeGeneratorDllPath);
+                string sharpmakeCommonPlatformsDllPath;
+                GetSharpmakeLocalDlls(out sharpmakeDllPath, out sharpmakeGeneratorDllPath, out sharpmakeCommonPlatformsDllPath);
 
                 conf.ReferencesByPath.Add(sharpmakeDllPath);
                 conf.ReferencesByPath.Add(sharpmakeGeneratorDllPath);
+                conf.ReferencesByPath.Add(sharpmakeCommonPlatformsDllPath);
             }
 
-            protected static void GetSharpmakeLocalDlls(out string sharpmakeDllPath, out string sharpmakeGeneratorDllPath)
+            protected static void GetSharpmakeLocalDlls(out string sharpmakeDllPath, out string sharpmakeGeneratorDllPath, out string sharpmakeCommonPlatformsDllPath)
             {
                 sharpmakeDllPath = Assembly.GetExecutingAssembly().Location;
                 sharpmakeGeneratorDllPath = Assembly.Load("Sharpmake.Generators")?.Location;
+                sharpmakeCommonPlatformsDllPath = Assembly.Load("Sharpmake.CommonPlatforms")?.Location;
             }
 
             public virtual void AddReferences(Project.Configuration conf, IEnumerable<string> additionalReferences = null)


### PR DESCRIPTION
Added Sharpmake.CommonPlatforms to the list of References for the DebugSolution and Project.

When using Android targets, specifically anything under `Sharpmake.Android`, the debug solution and project fail to run due to `Sharpmake.Android` not being recognized.

It produces the following error when you try to build/run the debug project.
```
1>S:\code\projects\temp\Sharpmake\samples\HelloAndroidAgde\HelloAndroidAgde.CommonTarget.sharpmake.cs(11,43,11,50):
error CS0234: The type or namespace name 'Android' does not exist in the namespace 'Sharpmake' (are you missing an assembly reference?)
```
Can try to replicate the error under the HelloAndroidAgde sample.

This change simply adds the `Sharpmake.CommonPlatforms` DLL as a reference which fixes the issue.