### PR TITLE
Fix crash when using AdditionalManifestFiles on 32-bit Windows targets

### DIFF
--- a/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Windows/BaseWindowsPlatform.cs
+++ b/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Windows/BaseWindowsPlatform.cs
@@ -12,6 +12,13 @@ namespace Sharpmake
     {
         public abstract class BaseWindowsPlatform : BaseMicrosoftPlatform, IWindowsFastBuildCompilerSettings
         {
+            #region IPlatformDescriptor implementation
+            public override EnvironmentVariableResolver GetPlatformEnvironmentResolver(params VariableAssignment[] assignments)
+            {
+                return new Win64EnvironmentVariableResolver(assignments);
+            }
+            #endregion
+            
             #region IWindowsFastBuildCompilerSettings implementation
             public override bool IsPcPlatform => true;
             public IDictionary<DevEnv, string> BinPath { get; set; } = new Dictionary<DevEnv, string>();

--- a/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Windows/Win64Platform.cs
+++ b/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Windows/Win64Platform.cs
@@ -26,11 +26,6 @@ namespace Sharpmake
             #region IPlatformDescriptor implementation
             public override string SimplePlatformString => "Win64";
             public override string GetToolchainPlatformString(ITarget target) => "x64";
-
-            public override EnvironmentVariableResolver GetPlatformEnvironmentResolver(params VariableAssignment[] assignments)
-            {
-                return new Win64EnvironmentVariableResolver(assignments);
-            }
             #endregion
 
             #region IMicrosoftPlatformBff implementation


### PR DESCRIPTION
Fixes a crash that appears when you add additional manifest files while targeting 32-bit Windows. The crash is caused by `EnvironmentVariableResolver` for that platform being null.

```
[ERROR]                                              
Error:                                               
Object reference not set to an instance of an object.
        While running D:\src\Sharpmake\Sharpmake.Application\bin\Debug\net6.0\Sharpmake.Application.exe
        @06/20/2025 04:16:31: Exception message (level 0):
        Error encountered while generating HelloWorld.HelloWorldProject
        Inner exception message (level 1):
        Object reference not set to an instance of an object.

        Stack trace:
        Inner exception stack trace (level 1):
   at Sharpmake.Generators.FastBuild.Bff.CmdLineConvertIncludePathsFunc(IGenerationContext context, Resolver resolver, String include, String prefix) in D:\src\Sharpmake\Sharpmake.Generators\FastBuild\Bff.cs:line 1558
   at Sharpmake.Generators.VisualStudio.ProjectOptionsGenerator.<>c__DisplayClass18_0.<GenerateManifestToolOptions>b__4(String p) in D:\src\Sharpmake\Sharpmake.Generators\VisualStudio\ProjectOptionsGenerator.cs:line 1912
   at System.Linq.Enumerable.SelectEnumerableIterator`2.MoveNext()
   at System.String.Join(String separator, IEnumerable`1 values)
   at Sharpmake.Generators.VisualStudio.ProjectOptionsGenerator.GenerateManifestToolOptions(IGenerationContext context, ProjectOptionsGenerationContext optionsContext) in D:\src\Sharpmake\Sharpmake.Generators\VisualStudio\ProjectOptionsGenerator
.cs:line 1914
   at Sharpmake.Generators.VisualStudio.ProjectOptionsGenerator.GenerateOptions(IGenerationContext context, ProjectOptionGenerationLevel level) in D:\src\Sharpmake\Sharpmake.Generators\VisualStudio\ProjectOptionsGenerator.cs:line 97
   at Sharpmake.Generators.VisualStudio.Vcxproj.GenerateConfOptions(GenerationContext context) in D:\src\Sharpmake\Sharpmake.Generators\VisualStudio\Vcxproj.cs:line 350
   at Sharpmake.Generators.VisualStudio.Vcxproj.GenerateImpl(GenerationContext context, IList`1 generatedFiles, IList`1 skipFiles) in D:\src\Sharpmake\Sharpmake.Generators\VisualStudio\Vcxproj.cs:line 363
   at Sharpmake.Generators.VisualStudio.Vcxproj.Generate(Builder builder, Project project, List`1 configurations, String projectFile, List`1 generatedFiles, List`1 skipFiles) in D:\src\Sharpmake\Sharpmake.Generators\VisualStudio\Vcxproj.cs:line 
144
   at Sharpmake.Generators.GeneratorManager.Generate(Builder builder, Project project, List`1 configurations, String projectFile, List`1 generatedFiles, List`1 skipFiles) in D:\src\Sharpmake\Sharpmake.Generators\GeneratorManager.cs:line 103     
   at Sharpmake.Builder.GenerateProjectFile(Object arg) in D:\src\Sharpmake\Sharpmake\Builder.cs:line 1302
        Root stack trace (level 0):
   at Sharpmake.Application.Program.CreateBuilderAndGenerate(BaseBuildContext buildContext, Argument parameters, Boolean generateDebugSolution) in D:\src\Sharpmake\Sharpmake.Application\Program.cs:line 481
   at Sharpmake.Application.Program.GenerateAll(BaseBuildContext buildContext, Argument parameters) in D:\src\Sharpmake\Sharpmake.Application\Program.cs:line 520
   at Sharpmake.Application.Program.Main() in D:\src\Sharpmake\Sharpmake.Application\Program.cs:line 307

1 errors, 0 warnings
```

To reproduce, use this (assuming `[project.SourceRootPath]\app.manifest` points to a valid manifest file location) and try generating targeting Win32 (not Win64) platform:
```cpp
conf.Options.Add(Options.CSharp.GenerateManifests.Enabled);
conf.AdditionalManifestFiles.Add(@"[project.SourceRootPath]\app.manifest");
```