### PR TITLE
Remove jobs that requires windows-2019 image from GitHub pipeline

### DIFF
--- a/.github/Get-SamplesMatrixJson.ps1
+++ b/.github/Get-SamplesMatrixJson.ps1
@@ -20,6 +20,9 @@ $matrixInclude = foreach ($sample in $samplesDef.Samples)
     {
         foreach ($os in $sample.OSs)
         {
+            # Skip if windows-2019. This image is no longer available.
+            if ($os -eq 'windows-2019') { continue }
+
             foreach ($framework in $sample.Frameworks)
             {
                 # Map os to GitLab runner label

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019] # only windows for now, but ideally should be all. TODO: add windows-2022
+        os: [windows-2022]
         framework: [net6.0]
 
     steps:

--- a/Sharpmake.FunctionalTests/FastBuildFunctionalTest/FastBuildFunctionalTest.sharpmake.cs
+++ b/Sharpmake.FunctionalTests/FastBuildFunctionalTest/FastBuildFunctionalTest.sharpmake.cs
@@ -107,7 +107,7 @@ namespace SharpmakeGen.FunctionalTests
             var targets = new List<ITarget> {
                 new Target(
                     Platform.win64,
-                    DevEnv.vs2019,
+                    DevEnv.vs2022,
                     Optimization.Debug | Optimization.Release,
                     Blob.NoBlob,
                     BuildSystem.MSBuild
@@ -697,10 +697,10 @@ namespace SharpmakeGen.FunctionalTests
 
             // This is just to insure that we are able to generate some custom property section when referenced from a Compiler section
             FastBuildSettings.AdditionalPropertyGroups.Add("function TestCustomProperties()", new List<string> { "Print('Hello Custom Property')", "Print('Hello Custom Property2')" });
-            FastBuildSettings.AdditionalCompilerPropertyGroups.Add("Compiler-x64-vs2019", "function TestCustomProperties()");
-            FastBuildSettings.AdditionalCompilerSettings.Add("Compiler-x64-vs2019", new List<string> { "TestCustomProperties()" });
+            FastBuildSettings.AdditionalCompilerPropertyGroups.Add("Compiler-x64-vs2022", "function TestCustomProperties()");
+            FastBuildSettings.AdditionalCompilerSettings.Add("Compiler-x64-vs2022", new List<string> { "TestCustomProperties()" });
 
-            KitsRootPaths.SetUseKitsRootForDevEnv(DevEnv.vs2019, KitsRootEnum.KitsRoot10, Options.Vc.General.WindowsTargetPlatformVersion.v10_0_19041_0);
+            KitsRootPaths.SetUseKitsRootForDevEnv(DevEnv.vs2022, KitsRootEnum.KitsRoot10, Options.Vc.General.WindowsTargetPlatformVersion.v10_0_19041_0);
 
             Bff.UnityResolver = new Bff.FragmentUnityResolver();
 

--- a/Sharpmake.FunctionalTests/NoAllFastBuildProjectFunctionalTest/NoAllFastBuildProjectFunctionalTest.sharpmake.cs
+++ b/Sharpmake.FunctionalTests/NoAllFastBuildProjectFunctionalTest/NoAllFastBuildProjectFunctionalTest.sharpmake.cs
@@ -24,7 +24,7 @@ namespace SharpmakeGen.FunctionalTests
         {
             return new Target(
                 Platform.win64,
-                DevEnv.vs2019,
+                DevEnv.vs2022,
                 Optimization.Debug | Optimization.Release
             );
         }
@@ -194,7 +194,7 @@ namespace SharpmakeGen.FunctionalTests
             FastBuildSettings.FastBuildWait = true;
             FastBuildSettings.WriteAllConfigsSection = true;
 
-            KitsRootPaths.SetUseKitsRootForDevEnv(DevEnv.vs2019, KitsRootEnum.KitsRoot10, Options.Vc.General.WindowsTargetPlatformVersion.v10_0_19041_0);
+            KitsRootPaths.SetUseKitsRootForDevEnv(DevEnv.vs2022, KitsRootEnum.KitsRoot10, Options.Vc.General.WindowsTargetPlatformVersion.v10_0_19041_0);
 
             Bff.UnityResolver = new Bff.FragmentUnityResolver();
 

--- a/Sharpmake.FunctionalTests/OnlyNeededFastBuildTest/OnlyNeededFastBuildTest.sharpmake.cs
+++ b/Sharpmake.FunctionalTests/OnlyNeededFastBuildTest/OnlyNeededFastBuildTest.sharpmake.cs
@@ -96,7 +96,7 @@ namespace SharpmakeGen.FunctionalTests
             var targets = new List<ITarget> {
                 new Target(
                     Platform.win64,
-                    DevEnv.vs2019,
+                    DevEnv.vs2022,
                     Optimization.Debug | Optimization.Release,
                     Blob.NoBlob,
                     BuildSystem.MSBuild
@@ -236,7 +236,7 @@ namespace SharpmakeGen.FunctionalTests
             FastBuildSettings.FastBuildWait = true;
             FastBuildSettings.WriteAllConfigsSection = true;
 
-            KitsRootPaths.SetUseKitsRootForDevEnv(DevEnv.vs2019, KitsRootEnum.KitsRoot10, Options.Vc.General.WindowsTargetPlatformVersion.Latest);
+            KitsRootPaths.SetUseKitsRootForDevEnv(DevEnv.vs2022, KitsRootEnum.KitsRoot10, Options.Vc.General.WindowsTargetPlatformVersion.Latest);
 
             Bff.UnityResolver = new Bff.FragmentUnityResolver();
 

--- a/functional_test.py
+++ b/functional_test.py
@@ -107,7 +107,7 @@ class FastBuildFunctionalTest(FunctionalTest):
 
     def verifyCustomBuildEvents(self, projectDir):
         output_dir = os.path.join(projectDir, self.directory, "projects", "output")
-        target_dirs = ["debug_fastbuild_noblob_vs2019", "debug_fastbuild_vs2019", "release_fastbuild_noblob_vs2019", "release_fastbuild_vs2019"]
+        target_dirs = ["debug_fastbuild_noblob_vs2022", "debug_fastbuild_vs2022", "release_fastbuild_noblob_vs2022", "release_fastbuild_vs2022"]
 
         for target_dir in target_dirs:
             target_dir = os.path.join(output_dir, target_dir)


### PR DESCRIPTION
This image has been retired and is no longer available.