### PR TITLE
Clang AdditionalLibrarianOptions support

### DIFF
--- a/Sharpmake.Generators/FastBuild/Bff.Template.cs
+++ b/Sharpmake.Generators/FastBuild/Bff.Template.cs
@@ -353,6 +353,7 @@ Compiler( '[fastBuildNasmCompilerName]' )
                 public static string LibrarianOptionsClang = @"
     .LibrarianOutput        = '[fastBuildOutputFile]'
     .LibrarianOptions       = 'rcs[cmdLineOptions.UseThinArchives] ""%2"" ""%1""'
+                            + ' [options.AdditionalLibrarianOptions]'
 
 ";
 


### PR DESCRIPTION
Add support for AdditionalLibrarianOptions when generating bff files using clang as compiler and its librarian.

Seems like a simple oversight that it's missing since LibrarianOptions just above LibrarianOptionsClang when using MSVC has it.

All unit and regression tests pass after this change.