### PR TITLE
Extend FASTBuild bff generator to support CustomFileBuildStep.AdditionalInputs

### DIFF
--- a/Sharpmake.Generators/FastBuild/Bff.Util.cs
+++ b/Sharpmake.Generators/FastBuild/Bff.Util.cs
@@ -859,9 +859,16 @@ namespace Sharpmake.Generators.FastBuild
                     return relativePath;
             });
 
+            Strings inputFiles = new();
+            inputFiles.Add(relativeBuildStep.KeyInput);
+            foreach (string inputFile in relativeBuildStep.AdditionalInputs)
+            {
+                inputFiles.Add(inputFile);
+            }
+
             using (bffGenerator.Declare("fastBuildPreBuildName", relativeBuildStep.Description))
             using (bffGenerator.Declare("fastBuildPrebuildExeFile", relativeBuildStep.Executable))
-            using (bffGenerator.Declare("fastBuildPreBuildInputFiles", FBuildFormatSingleListItem(relativeBuildStep.KeyInput)))
+            using (bffGenerator.Declare("fastBuildPreBuildInputFiles", FBuildFormatList(inputFiles.ToList(), 26)))
             using (bffGenerator.Declare("fastBuildPreBuildOutputFile", relativeBuildStep.Output))
             using (bffGenerator.Declare("fastBuildPreBuildArguments", string.IsNullOrWhiteSpace(relativeBuildStep.ExecutableArguments) ? FileGeneratorUtilities.RemoveLineTag : relativeBuildStep.ExecutableArguments))
             // This is normally the project directory.

--- a/Sharpmake/Project.Configuration.cs
+++ b/Sharpmake/Project.Configuration.cs
@@ -2360,7 +2360,6 @@ namespace Sharpmake
                 public string OutputItemType = "";
 
                 /// <summary>
-                /// Not supported by FASTBuild.
                 /// Additional files that will cause a re-run of this custom build step can be be specified here.
                 /// </summary>
                 public Strings AdditionalInputs = new Strings();


### PR DESCRIPTION
For some reason Sharpmake currently doesn't support having multiple inputs for the FASTBuild `.Exec` function generated from CustomFileBuildStep whereas it does for the `.Exec` function generated from the custom pre or post build exe steps.

FASTBuild `.Exec` supports multiple input files, so it's fairly trivial to support this and it's useful for correct dependency checking of per-file custom build steps.