### PR TITLE
Minor custom build step resolving improvement/fix

### DIFF
--- a/Sharpmake.Generators/FastBuild/Bff.Util.cs
+++ b/Sharpmake.Generators/FastBuild/Bff.Util.cs
@@ -879,6 +879,7 @@ namespace Sharpmake.Generators.FastBuild
         {
             using (bffGenerator.Resolver.NewScopedParameter("project", project))
             using (bffGenerator.Resolver.NewScopedParameter("config", config))
+            using (bffGenerator.Resolver.NewScopedParameter("conf", config))
             using (bffGenerator.Resolver.NewScopedParameter("target", config.Target))
             {
                 foreach (var customBuildStep in config.CustomFileBuildSteps)

--- a/Sharpmake.Generators/VisualStudio/Vcxproj.cs
+++ b/Sharpmake.Generators/VisualStudio/Vcxproj.cs
@@ -1391,6 +1391,7 @@ namespace Sharpmake.Generators.VisualStudio
                 {
                     using (fileGenerator.Resolver.NewScopedParameter("project", context.Project))
                     using (fileGenerator.Resolver.NewScopedParameter("config", config))
+                    using (fileGenerator.Resolver.NewScopedParameter("conf", config))
                     using (fileGenerator.Resolver.NewScopedParameter("target", config.Target))
                     {
                         var customFileBuildSteps = CombineCustomFileBuildSteps(context.ProjectDirectory, fileGenerator.Resolver, config.CustomFileBuildSteps.Where(step => step.Filter != Project.Configuration.CustomFileBuildStep.ProjectFilter.BFFOnly));


### PR DESCRIPTION
Also supply 'conf' for the current configuration when resolving a custom build step.

In all cases Sharpmake uses 'conf' as resolve parameter name when resolving Sharpmake strings. But in the case of custom build steps 'config' is used instead and 'conf' isn't specified. This seems like a simple oversight, so this change also adds 'conf' for consistency.