### PR TITLE
Add a new /logAllGeneratedSolutions command line argument

### DIFF
--- a/Sharpmake.Application/CommandLineArguments.cs
+++ b/Sharpmake.Application/CommandLineArguments.cs
@@ -50,6 +50,7 @@ namespace Sharpmake.Application
             public bool Diagnostics = false;
             public bool WriteFiles = true;
             public bool DumpDependency = false;
+            public bool LogAllGeneratedSolutions = false;
             private bool _testOptionValid = true;
             internal TestOptions TestOption;
             internal bool RegressionDiff = true;
@@ -100,6 +101,12 @@ namespace Sharpmake.Application
             {
                 Tools.ProjectLogFiles(projectFile);
                 Exit = true;
+            }
+
+            [CommandLine.Option("logAllGeneratedSolutions", "Log all solution files considered and generated to the console: ex: /logAllGeneratedSolutions")]
+            public void CommandLineLogAllGeneratedSolutions()
+            {
+                LogAllGeneratedSolutions = true;
             }
 
             [CommandLine.Option("blobonly", @"Only generate blob and work blob files: ex: /blobonly")]

--- a/Sharpmake.Application/Program.cs
+++ b/Sharpmake.Application/Program.cs
@@ -487,7 +487,7 @@ namespace Sharpmake.Application
                     if (parameters.DumpDependency)
                         DependencyTracker.Instance.DumpGraphs(outputs);
 
-                    LogWriteGenerateResults(outputs);
+                    LogWriteGenerateResults(outputs, parameters);
                 }
             }
 
@@ -555,7 +555,7 @@ namespace Sharpmake.Application
             return ExitCode.Success;
         }
 
-        public static void LogWriteGenerateResults(IDictionary<Type, GenerationOutput> outputs)
+        public static void LogWriteGenerateResults(IDictionary<Type, GenerationOutput> outputs, Argument parameters)
         {
             var projects = outputs.Where(o => typeof(Project).IsAssignableFrom(o.Key));
             var solutions = outputs.Where(o => typeof(Solution).IsAssignableFrom(o.Key));
@@ -616,6 +616,22 @@ namespace Sharpmake.Application
 
             if (generatedOtherFiles.Count > 0 || skippedOtherFiles.Count > 0)
                 LogWriteLine("    other files                      {0,5} generated, {1,5} up-to-date", generatedOtherFiles.Count, skippedOtherFiles.Count);
+
+            if (parameters.LogAllGeneratedSolutions && generatedSolutionFiles.Count + skippedSolutionFiles.Count > 0)
+            {
+                LogWriteLine("  All Generated Solutions:");
+                foreach (string solutionFile in generatedSolutionFiles)
+                {
+                    LogWriteLine("    " + solutionFile);
+                }
+                foreach (string solutionFile in skippedSolutionFiles)
+                {
+                    if (File.Exists(solutionFile)) // Some skipped files may end up being empty and then they aren't written to disk, check for that here
+                    {
+                        LogWriteLine("    " + solutionFile);
+                    }
+                }
+            }
         }
 
         public static Builder CreateBuilder(BuildContext.BaseBuildContext context, Argument parameters, bool allowCleanBlobs, bool generateDebugSolution = false)


### PR DESCRIPTION
Add a new /logAllGeneratedSolutions command line argument to Sharpmake to force it to log all the generated .sln files (even the ones that were up-to-date).

By default Sharpmake only logs .sln files it actually generated/wrote in the particular run but not the ones that were skipped because they didn't change. We use this on our continuous integration infrastructure and other places to easily gather which .slns are generated.
Maybe others find this useful as well.
