### PR TITLE
Extend FASTBuild bff generator to support CustomFileBuildStep.AdditionalInputs

### DIFF
--- a/Sharpmake.Generators/FastBuild/Bff.Util.cs
+++ b/Sharpmake.Generators/FastBuild/Bff.Util.cs
@@ -859,9 +859,16 @@ namespace Sharpmake.Generators.FastBuild
                     return relativePath;
             });
 
+            Strings inputFiles = new();
+            inputFiles.Add(relativeBuildStep.KeyInput);
+            foreach (string inputFile in relativeBuildStep.AdditionalInputs)
+            {
+                inputFiles.Add(inputFile);
+            }
+
             using (bffGenerator.Declare("fastBuildPreBuildName", relativeBuildStep.Description))
             using (bffGenerator.Declare("fastBuildPrebuildExeFile", relativeBuildStep.Executable))
-            using (bffGenerator.Declare("fastBuildPreBuildInputFiles", FBuildFormatSingleListItem(relativeBuildStep.KeyInput)))
+            using (bffGenerator.Declare("fastBuildPreBuildInputFiles", FBuildFormatList(inputFiles.ToList(), 26)))
             using (bffGenerator.Declare("fastBuildPreBuildOutputFile", relativeBuildStep.Output))
             using (bffGenerator.Declare("fastBuildPreBuildArguments", string.IsNullOrWhiteSpace(relativeBuildStep.ExecutableArguments) ? FileGeneratorUtilities.RemoveLineTag : relativeBuildStep.ExecutableArguments))
             // This is normally the project directory.

--- a/Sharpmake/Project.Configuration.cs
+++ b/Sharpmake/Project.Configuration.cs
@@ -2360,7 +2360,6 @@ namespace Sharpmake
                 public string OutputItemType = "";
 
                 /// <summary>
-                /// Not supported by FASTBuild.
                 /// Additional files that will cause a re-run of this custom build step can be be specified here.
                 /// </summary>
                 public Strings AdditionalInputs = new Strings();

--- a/samples/CustomBuildStep/CustomBuildStep.sharpmake.cs
+++ b/samples/CustomBuildStep/CustomBuildStep.sharpmake.cs
@@ -14,7 +14,7 @@ namespace FastBuild
             SourceRootPath = @"[project.SharpmakeCsPath]\codebase";
             SourceFilesExtensions.Add(".bat");
 
-            // need to add it explicitly since it's gonna be generated it doesn't exist yet
+            // need to add generated files explicitly since they don't exist yet
             SourceFiles.Add(@"[project.SourceRootPath]\main.cpp");
             SourceFiles.Add(@"[project.SourceRootPath]\secondaryfile.cpp");
 
@@ -33,6 +33,7 @@ namespace FastBuild
         [Configure]
         public void ConfigureAll(Configuration conf, Target target)
         {
+            // A simple custom build step that generates main.cpp via a .bat file
             conf.CustomFileBuildSteps.Add(
                 new Configuration.CustomFileBuildStep
                 {
@@ -41,13 +42,17 @@ namespace FastBuild
                     Description = $"Generate main.cpp",
                     Executable = "generatemain.bat"
                 });
+            // Demonstrates a custom file build step that has two inputs and one output
             conf.CustomFileBuildSteps.Add(
                 new Configuration.CustomFileBuildStep
                 {
                     KeyInput = "generatesecondaryfile.bat",
                     Output = "secondaryfile.cpp",
                     Description = $"Generate secondaryfile.cpp",
-                    Executable = "generatesecondaryfile.bat"
+                    Executable = "generatesecondaryfile.bat",
+                    ExecutableArguments = "../codebase/concatenate_file1.in ../codebase/concatenate_file2.in",
+                    AdditionalInputs = { "[project.SourceRootPath]\\concatenate_file1.in", "[project.SourceRootPath]\\concatenate_file2.in" }
+				
                 });
 
             conf.ProjectFileName = "[project.Name]_[target.DevEnv]_[target.Platform]";

--- a/samples/CustomBuildStep/codebase/concatenate_file1.in
+++ b/samples/CustomBuildStep/codebase/concatenate_file1.in
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+const char *GetFile1Content()
+{
+    return "This is the content of file 1.\n";
+}

--- a/samples/CustomBuildStep/codebase/concatenate_file2.in
+++ b/samples/CustomBuildStep/codebase/concatenate_file2.in
@@ -1,0 +1,10 @@
+const char *GetFile2Content()
+{
+    return "This is the content of file 2.\n";
+}
+
+void PrintSecondaryFileContent()
+{
+    printf("%s", GetFile1Content());
+    printf("%s", GetFile2Content());
+}

--- a/samples/CustomBuildStep/codebase/generatesecondaryfile.bat
+++ b/samples/CustomBuildStep/codebase/generatesecondaryfile.bat
@@ -1,15 +1,18 @@
 @echo off
 setlocal
 
-set OUTPUT=%~dp0secondaryfile.cpp
-echo Generating %OUTPUT%
+if "%~2"=="" goto :usage
 
-:: Note: ^ is used to escape < and >
-> "%OUTPUT%" echo #include ^<stdio.h^>
->>"%OUTPUT%" echo void PrintSecondaryFileContent()
->>"%OUTPUT%" echo {
->>"%OUTPUT%" echo     printf("This is secondary file\n");
->>"%OUTPUT%" echo }
+set OUTPUT=%~dp0\secondaryfile.cpp
 
-echo Done
+echo Concatenating "%~f1" + "%~f2" into "%OUTPUT%"
+>"%OUTPUT%" type "%~f1"
+>>"%OUTPUT%" type "%~f2"
+
+echo Done.
 goto :eof
+
+:usage
+echo Usage: %~n0 file1.cpp file2.cpp
+echo Concatenates file1.cpp and file2.cpp into %~dp0concatenated.cpp
+exit /b 1


### PR DESCRIPTION
For some reason Sharpmake currently doesn't support having multiple inputs for the FASTBuild `.Exec` function generated from `CustomFileBuildStep` whereas it does for the `.Exec` function generated from the custom pre or post build exe steps.

FASTBuild `.Exec` supports multiple input files, so it's fairly trivial to support this and it's useful for correct dependency checking of per-file custom build steps.