### PR TITLE
Minor fixes to SamplesDef.json and related Powershell scripts:

### DIFF
--- a/RunSharpmake.ps1
+++ b/RunSharpmake.ps1
@@ -31,15 +31,17 @@ try
     Write-Host "run sharpmake.application on $sharpmakeFile"
     $curentDir = Get-Location
 
-    $sharpmakeWinExe = Join-Path $curentDir 'Sharpmake.Application' 'bin' $configuration $framework 'Sharpmake.Application.exe'
-    $sharpmakeLinuxExe = Join-Path $curentDir 'Sharpmake.Application' 'bin' $configuration $framework 'Sharpmake.Application'
+    $sharpmakeWinExe = [IO.Path]::Combine($curentDir, 'Sharpmake.Application', 'bin', $configuration, $framework, 'Sharpmake.Application.exe')
+    $sharpmakeLinuxExe = [IO.Path]::Combine($curentDir, 'Sharpmake.Application', 'bin', $configuration, $framework, 'Sharpmake.Application')
     $arguments = "/sources('$sharpmakeFile') /verbose"
     if ($devenvVersion -ne "")
     {
         $arguments = "$arguments /devenvversion('$devenvVersion')"
     }
 
-    if ($IsWindows)
+    $onWindows = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)
+
+    if ($onWindows)
     {
         # run on windows
         Write-Host "running on windows"

--- a/SamplesDef.json
+++ b/SamplesDef.json
@@ -556,6 +556,6 @@
                 "./Compile.ps1 -slnOrPrjFile \"helloassemblynasm_{VsVersionSuffix}_win64_msbuild.sln\" -configuration {configuration} -platform \"x64\" -WorkingDirectory \"{testFolder}/projects\" -VsVersion {os} -compiler MsBuild",
                 "&'./{testFolder}/projects/output/win64/{configuration}/HelloAssemblyNasmExecutable.exe'"
             ]
-        },
+        }
     ]
 }


### PR DESCRIPTION
While trying to test a Sharpmake sample with the provided Powershell scripts `RunSample.ps1` and `RunSharpmake.ps1` on Windows I ran into two issues that this change fixes:
- `SamplesDef.json` was malformed and had a trailing comma that caused `RunSample.ps1` to fail parsing it correctly.
- `RunSharpmake.ps1` didn't correctly detect I was running on Windows and error-ed attempting to run `chmod`.