### PR TITLE
Change HelloXCode sample. Generate sln/vcxproj and be compatible with Rider on Mac

### DIFF
--- a/Sharpmake.Generators/GeneratorManager.cs
+++ b/Sharpmake.Generators/GeneratorManager.cs
@@ -120,56 +120,43 @@ namespace Sharpmake.Generators
         }
 
         public void Generate(Builder builder,
-                             Solution solution,
-                             List<Solution.Configuration> configurations,
-                             string solutionFile,
-                             List<string> generatedFiles,
-                             List<string> skipFiles)
+            Solution solution,
+            List<Solution.Configuration> configurations,
+            string solutionFile,
+            List<string> generatedFiles,
+            List<string> skipFiles)
         {
-            if (configurations[0].Platform == Platform.ios ||
-                configurations[0].Platform == Platform.mac ||
-                configurations[0].Platform == Platform.tvos ||
-                configurations[0].Platform == Platform.watchos ||
-                configurations[0].Platform == Platform.maccatalyst
-            )
+            if (UtilityMethods.HasFastBuildConfig(configurations))
             {
-                XCWorkspaceGenerator.Generate(builder, solution, configurations, solutionFile, generatedFiles, skipFiles);
-                if (UtilityMethods.HasFastBuildConfig(configurations))
-                {
-                    MasterBffGenerator.Generate(builder, solution, configurations, solutionFile, generatedFiles, skipFiles);
-                }
+                MasterBffGenerator.Generate(builder, solution, configurations, solutionFile, generatedFiles, skipFiles);
             }
-            else
-            {
-                DevEnv devEnv = configurations[0].Target.GetFragment<DevEnv>();
-                switch (devEnv)
-                {
-                    case DevEnv.make:
-                        {
-                            if (configurations[0].Platform == Platform.android)
-                                MakeApplicationGenerator.Generate(builder, solution, configurations, solutionFile, generatedFiles, skipFiles);
-                            else
-                                MakefileGenerator.Generate(builder, solution, configurations, solutionFile, generatedFiles, skipFiles);
-                            break;
-                        }
-                    case DevEnv.vs2015:
-                    case DevEnv.vs2017:
-                    case DevEnv.vs2019:
-                    case DevEnv.vs2022:
-                    case DevEnv.vs2026:
-                        {
-                            if (UtilityMethods.HasFastBuildConfig(configurations))
-                            {
-                                MasterBffGenerator.Generate(builder, solution, configurations, solutionFile, generatedFiles, skipFiles);
-                            }
 
-                            SlnGenerator.Generate(builder, solution, configurations, solutionFile, generatedFiles, skipFiles);
-                            break;
-                        }
-                    default:
-                        {
-                            throw new Error("Generate called with unknown DevEnv: " + devEnv);
-                        }
+            var devEnv = configurations[0].Target.GetFragment<DevEnv>();
+            switch (devEnv)
+            {
+                case DevEnv.xcode:
+                    XCWorkspaceGenerator.Generate(builder, solution, configurations, solutionFile, generatedFiles, skipFiles);
+                    break;
+                case DevEnv.make:
+                {
+                    if (configurations[0].Platform == Platform.android)
+                        MakeApplicationGenerator.Generate(builder, solution, configurations, solutionFile, generatedFiles, skipFiles);
+                    else
+                        MakefileGenerator.Generate(builder, solution, configurations, solutionFile, generatedFiles, skipFiles);
+                    break;
+                }
+                case DevEnv.vs2015:
+                case DevEnv.vs2017:
+                case DevEnv.vs2019:
+                case DevEnv.vs2022:
+                case DevEnv.vs2026:
+                {
+                    SlnGenerator.Generate(builder, solution, configurations, solutionFile, generatedFiles, skipFiles);
+                    break;
+                }
+                default:
+                {
+                    throw new Error("Generate called with unknown DevEnv: " + devEnv);
                 }
             }
         }

--- a/Sharpmake.Generators/VisualStudio/IPlatformVcxproj.cs
+++ b/Sharpmake.Generators/VisualStudio/IPlatformVcxproj.cs
@@ -41,6 +41,9 @@ namespace Sharpmake.Generators.VisualStudio
         bool HasUserAccountControlSupport { get; }
         bool HasEditAndContinueDebuggingSupport { get; }
 
+        // When false, the generator will skip the standard Microsoft.Cpp.*.props/targets imports.
+        bool IsMSVC { get; }
+
         IEnumerable<string> GetImplicitlyDefinedSymbols(IGenerationContext context);
 
         IEnumerable<string> GetLibraryPaths(IGenerationContext context);

--- a/Sharpmake.Generators/VisualStudio/Vcxproj.Template.cs
+++ b/Sharpmake.Generators/VisualStudio/Vcxproj.Template.cs
@@ -386,6 +386,9 @@ namespace Sharpmake.Generators.VisualStudio
                 public static string ProjectFilesSourceExcludeFromBuild =
                 @"      <ExcludedFromBuild Condition=""'$(Configuration)|$(Platform)'=='[conf.Name]|[platformName]'"">true</ExcludedFromBuild>
 ";
+                public static string ProjectFilesSourceRemoveFromBuild =
+                @"    <ClCompile Remove=""[file.FilePath]"" Condition=""'$(Configuration)|$(Platform)'=='[conf.Name]|[platformName]'"" />
+";
                 public static string ProjectFilesSourceConsumeWinRTExtensions =
                 @"      <CompileAsWinRT Condition=""'$(Configuration)|$(Platform)'=='[conf.Name]|[platformName]'"">true</CompileAsWinRT>
 ";

--- a/Sharpmake.Generators/VisualStudio/Vcxproj.Template.cs
+++ b/Sharpmake.Generators/VisualStudio/Vcxproj.Template.cs
@@ -88,9 +88,12 @@ namespace Sharpmake.Generators.VisualStudio
                 public static string ProjectEnd =
                 @"</Project>";
 
-                public static string ProjectAfterConfigurationsGeneral =
+                public static string MicrosoftCppProps =
 @"  <Import Project=""[vcTargetsPath]\Microsoft.Cpp.props"" />
-  <ImportGroup Label=""ExtensionSettings"">
+";
+
+                public static string ProjectAfterConfigurationsGeneral =
+@"  <ImportGroup Label=""ExtensionSettings"">
 ";
                 public static string ProjectAfterConfigurationsGeneralImportPropertySheets =
 @"  <ImportGroup Label=""PropertySheets"">
@@ -138,9 +141,12 @@ namespace Sharpmake.Generators.VisualStudio
                 @"  </ItemDefinitionGroup>
 ";
 
-                public static string ProjectTargetsBegin =
+                public static string ImportMicrosoftCppTargets =
 @"  <Import Project=""[vcTargetsPath]\Microsoft.Cpp.targets"" />
-  <ImportGroup Label=""ExtensionTargets"">
+";
+
+                public static string ProjectTargetsBegin =
+@"  <ImportGroup Label=""ExtensionTargets"">
 ";
 
                 public static string ProjectTargetsItem =

--- a/Sharpmake.Generators/VisualStudio/Vcxproj.Template.cs
+++ b/Sharpmake.Generators/VisualStudio/Vcxproj.Template.cs
@@ -188,6 +188,18 @@ namespace Sharpmake.Generators.VisualStudio
 @"  </Target>
 ";
 
+                public static string NMakeBuildTargets =
+@"  <Target Name=""Build"" Condition=""'$(NMakeBuildCommandLine)' != ''"" >
+    <Exec Command=""$(NMakeBuildCommandLine)"" WorkingDirectory=""$(NMakeWorkingDirectory)""/>
+  </Target>
+  <Target Name=""Rebuild"" Condition=""'$(NMakeReBuildCommandLine)' != ''"" >
+    <Exec Command=""$(NMakeReBuildCommandLine)"" WorkingDirectory=""$(NMakeWorkingDirectory)""/>
+  </Target>
+  <Target Name=""Clean"" Condition=""'$(NMakeCleanCommandLine)' != ''"" >
+    <Exec Command=""$(NMakeCleanCommandLine)"" WorkingDirectory=""$(NMakeWorkingDirectory)""/>
+  </Target>
+";
+
                 public static string ProjectConfigurationsResourceCompile =
                 @"    <ResourceCompile>[options.ResourceCompileTag]
       <PreprocessorDefinitions>[options.ResourcePreprocessorDefinitions];%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/Sharpmake.Generators/VisualStudio/Vcxproj.cs
+++ b/Sharpmake.Generators/VisualStudio/Vcxproj.cs
@@ -467,7 +467,9 @@ namespace Sharpmake.Generators.VisualStudio
             foreach (var platform in context.PresentPlatforms.Values)
                 platform.GenerateProjectPlatformSdkDirectoryDescription(context, fileGenerator);
 
-            fileGenerator.Write(Template.Project.ImportCppDefaultProps);
+            bool isMSVC = context.PresentPlatforms.Values.Any(p => p.IsMSVC);
+            if (isMSVC)
+                fileGenerator.Write(Template.Project.ImportCppDefaultProps);
 
             foreach (var platform in context.PresentPlatforms.Values)
                 platform.GeneratePostDefaultPropsImport(context, fileGenerator);
@@ -495,6 +497,8 @@ namespace Sharpmake.Generators.VisualStudio
             }
 
             // .props files
+            if (isMSVC)
+                fileGenerator.Write(Template.Project.MicrosoftCppProps);
             fileGenerator.Write(Template.Project.ProjectAfterConfigurationsGeneral);
             if (context.Project.ContainsASM)
             {
@@ -671,10 +675,13 @@ namespace Sharpmake.Generators.VisualStudio
 
             // .targets files
             {
+                if (isMSVC)
+                    fileGenerator.Write(Template.Project.ImportMicrosoftCppTargets);
                 fileGenerator.Write(Template.Project.ProjectTargetsBegin);
                 if (context.Project.ContainsASM)
                 {
-                    fileGenerator.Write(Template.Project.ProjectMasmTargetsItem);
+                    if (isMSVC)
+                        fileGenerator.Write(Template.Project.ProjectMasmTargetsItem);
                 }
                 if (context.Project.ContainsNASM)
                 {
@@ -682,9 +689,12 @@ namespace Sharpmake.Generators.VisualStudio
                     {
                         throw new ArgumentNullException("NasmExePath not set and needed for NASM assembly files.");
                     }
-                    using (fileGenerator.Declare("importedNasmTargetsFile", context.Project.NasmTargetsFile))
+                    if (isMSVC)
                     {
-                        fileGenerator.Write(Template.Project.ProjectNasmTargetsItem);
+                        using (fileGenerator.Declare("importedNasmTargetsFile", context.Project.NasmTargetsFile))
+                        {
+                            fileGenerator.Write(Template.Project.ProjectNasmTargetsItem);
+                        }
                     }
                 }
 
@@ -780,7 +790,8 @@ namespace Sharpmake.Generators.VisualStudio
             context.Options["AdditionalPlatformIncludeDirectories"] = platformIncludePaths.Any() ? Util.PathGetRelative(context.ProjectDirectory, platformIncludePaths).JoinStrings(";") : FileGeneratorUtilities.RemoveLineTag;
 
             var nmakeIncludeSearchPath = includePaths.Concat(platformIncludePaths);
-            context.Options["NMakeIncludeSearchPath"] = nmakeIncludeSearchPath.Any() ? Util.PathGetRelative(context.ProjectDirectory, nmakeIncludeSearchPath).JoinStrings(";") : FileGeneratorUtilities.RemoveLineTag;
+            
+            context.Options["NMakeIncludeSearchPath"] = nmakeIncludeSearchPath.Any() ? string.Join(";", nmakeIncludeSearchPath) : FileGeneratorUtilities.RemoveLineTag;
 
             // Fill resource include dirs
             var resourceIncludePaths = platformVcxproj.GetResourceIncludePaths(context);

--- a/Sharpmake.Generators/VisualStudio/Vcxproj.cs
+++ b/Sharpmake.Generators/VisualStudio/Vcxproj.cs
@@ -1605,6 +1605,9 @@ namespace Sharpmake.Generators.VisualStudio
             foreach (Project.Configuration conf in context.ProjectConfigurations)
                 configurationCompiledFiles.Add(new List<ProjectFile>());
 
+            // Collects files excluded from build on non-MSVC platforms; written as <ClCompile Remove> after the ItemGroup
+            var nonMSVCExcludedFiles = new List<(ProjectFile File, Project.Configuration Conf)>();
+
             bool hasCustomBuildForAllSources = context.ProjectConfigurations.First().CustomBuildForAllSources != null;
             if (hasCustomBuildForAllSources)
             {
@@ -1689,6 +1692,9 @@ namespace Sharpmake.Generators.VisualStudio
                             if (!isExcludeFromBuild && !isResource)
                                 compiledFiles.Add(file);
 
+                            if (isExcludeFromBuild && !platformVcxproj.IsMSVC && !isResource)
+                                nonMSVCExcludedFiles.Add((file, conf));
+
                             if (isCompileAsCLRFile || consumeWinRTExtensions || excludeWinRTExtensions)
                                 isDontUsePrecomp = true;
                             if (string.Compare(file.FileExtension, ".c", StringComparison.OrdinalIgnoreCase) == 0)
@@ -1711,7 +1717,7 @@ namespace Sharpmake.Generators.VisualStudio
                             bool hasExceptionSetting = !string.IsNullOrEmpty(exceptionSetting);
 
                             haveFileOptions = haveFileOptions ||
-                                              isExcludeFromBuild ||
+                                              (isExcludeFromBuild && platformVcxproj.IsMSVC) ||
                                               isPrecompSource ||
                                               (isDontUsePrecomp && hasPrecomp) ||
                                               hasForcedIncludes ||
@@ -1750,7 +1756,8 @@ namespace Sharpmake.Generators.VisualStudio
 
                                     if (isExcludeFromBuild)
                                     {
-                                        fileGenerator.Write(Template.Project.ProjectFilesSourceExcludeFromBuild);
+                                        if (platformVcxproj.IsMSVC) 
+                                            fileGenerator.Write(Template.Project.ProjectFilesSourceExcludeFromBuild);
                                     }
                                     else
                                     {
@@ -2009,6 +2016,20 @@ namespace Sharpmake.Generators.VisualStudio
                                 + Environment.NewLine + "{2}" + Environment.NewLine + "{3}.{4}",
                                 conf, l.FileNameWithoutExtension, l.FileNameProjectRelative, r.FileNameProjectRelative, plausibleCause);
                         throw new Error(message);
+                    }
+                }
+            }
+            
+            // Write <ClCompile Remove> entries for files excluded from build on non-MSVC platforms
+            if (nonMSVCExcludedFiles.Count > 0)
+            {
+                foreach (var (excludedFile, excludedConf) in nonMSVCExcludedFiles)
+                {
+                    using (fileGenerator.Declare("file", excludedFile))
+                    using (fileGenerator.Declare("conf", excludedConf))
+                    using (fileGenerator.Declare("platformName", Util.GetToolchainPlatformString(excludedConf.Platform, excludedConf.Project, excludedConf.Target)))
+                    {
+                        fileGenerator.Write(Template.Project.ProjectFilesSourceRemoveFromBuild);
                     }
                 }
             }

--- a/Sharpmake.Generators/VisualStudio/Vcxproj.cs
+++ b/Sharpmake.Generators/VisualStudio/Vcxproj.cs
@@ -764,6 +764,9 @@ namespace Sharpmake.Generators.VisualStudio
                     platform.GenerateRunFromPcDeployment(context, fileGenerator);
             }
 
+            if (!isMSVC)
+                fileGenerator.Write(Template.Project.NMakeBuildTargets);
+
             fileGenerator.Write(Template.Project.ProjectEnd);
 
             // remove all line that contain RemoveLineTag

--- a/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Apple/BaseApplePlatform.cs
+++ b/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Apple/BaseApplePlatform.cs
@@ -1730,11 +1730,30 @@ namespace Sharpmake
   </PropertyGroup>
 ";
 
+        private const string _projectConfigurationsFastBuildMakefile =
+            @"  <PropertyGroup Condition=""'$(Configuration)|$(Platform)'=='[conf.Name]|[platformName]'"">
+    <NMakeBuildCommandLine>cd [fastBuildWorkingDirectory]
+[conf.FastBuildCustomActionsBeforeBuildCommand]
+[fastBuildMakeCommandBuild] </NMakeBuildCommandLine>
+    <NMakeReBuildCommandLine>cd [fastBuildWorkingDirectory]
+[conf.FastBuildCustomActionsBeforeBuildCommand]
+[fastBuildMakeCommandRebuild] </NMakeReBuildCommandLine>
+    <NMakePreprocessorDefinitions>[EscapeXML:options.PreprocessorDefinitions][EscapeXML:options.IntellisenseAdditionalDefines]</NMakePreprocessorDefinitions>
+    <NMakeIncludeSearchPath>[options.NMakeIncludeSearchPath]</NMakeIncludeSearchPath>
+    <NMakeForcedIncludes>[options.ForcedIncludeFiles]</NMakeForcedIncludes>
+    <AdditionalOptions>[options.IntellisenseCommandLineOptions]</AdditionalOptions>
+  </PropertyGroup>
+";
+
         private const string _projectConfigurationsCustomMakefile =
             @"  <PropertyGroup Condition=""'$(Configuration)|$(Platform)'=='[conf.Name]|[platformName]'"">
     <NMakeBuildCommandLine>[conf.CustomBuildSettings.BuildCommand]</NMakeBuildCommandLine>
     <NMakeReBuildCommandLine>[conf.CustomBuildSettings.RebuildCommand]</NMakeReBuildCommandLine>
     <NMakeCleanCommandLine>[conf.CustomBuildSettings.CleanCommand]</NMakeCleanCommandLine>
+    <NMakePreprocessorDefinitions>[EscapeXML:options.PreprocessorDefinitions][EscapeXML:options.IntellisenseAdditionalDefines]</NMakePreprocessorDefinitions>
+    <NMakeIncludeSearchPath>[options.NMakeIncludeSearchPath]</NMakeIncludeSearchPath>
+    <NMakeForcedIncludes>[options.ForcedIncludeFiles]</NMakeForcedIncludes>
+    <AdditionalOptions>[options.IntellisenseCommandLineOptions]</AdditionalOptions>
   </PropertyGroup>
 ";
 
@@ -1745,7 +1764,7 @@ namespace Sharpmake
 
         public void GenerateProjectConfigurationFastBuildMakeFile(IVcxprojGenerationContext context, IFileGenerator generator)
         {
-            // throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
+            generator.Write(_projectConfigurationsFastBuildMakefile);
         }
 
         public void GenerateProjectConfigurationCustomMakeFile(IVcxprojGenerationContext context, IFileGenerator generator)

--- a/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Apple/BaseApplePlatform.cs
+++ b/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Apple/BaseApplePlatform.cs
@@ -1456,7 +1456,7 @@ namespace Sharpmake
 
         public void SelectPlatformAdditionalDependenciesOptions(IGenerationContext context)
         {
-            throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
+            // throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
         }
 
         public void SelectApplicationFormatOptions(IGenerationContext context)
@@ -1469,7 +1469,7 @@ namespace Sharpmake
 
         public virtual void SelectPreprocessorDefinitionsVcxproj(IVcxprojGenerationContext context)
         {
-            throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
+            // throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
         }
 
         public bool HasPrecomp(IGenerationContext context)
@@ -1479,92 +1479,92 @@ namespace Sharpmake
 
         public void GenerateSdkVcxproj(IVcxprojGenerationContext context, IFileGenerator generator)
         {
-            throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
+            // throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
         }
 
         public void GenerateMakefileConfigurationVcxproj(IVcxprojGenerationContext context, IFileGenerator generator)
         {
-            throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
+            // throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
         }
 
         public void GenerateProjectCompileVcxproj(IVcxprojGenerationContext context, IFileGenerator generator)
         {
-            throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
+            // throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
         }
 
         public void GenerateProjectLinkVcxproj(IVcxprojGenerationContext context, IFileGenerator generator)
         {
-            throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
+            // throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
         }
 
         public void GenerateProjectMasmVcxproj(IVcxprojGenerationContext context, IFileGenerator generator)
         {
-            throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
+            // throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
         }
 
         public void GenerateProjectNasmVcxproj(IVcxprojGenerationContext context, IFileGenerator generator)
         {
-            throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
+            // throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
         }
 
         public void GenerateUserConfigurationFile(Project.Configuration conf, IFileGenerator generator)
         {
-            throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
+            // throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
         }
 
         public void GenerateRunFromPcDeployment(IVcxprojGenerationContext context, IFileGenerator generator)
         {
-            throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
+            // throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
         }
 
         public void GeneratePlatformSpecificProjectDescription(IVcxprojGenerationContext context, IFileGenerator generator)
         {
-            throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
+            // throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
         }
 
         public void GenerateProjectPlatformSdkDirectoryDescription(IVcxprojGenerationContext context, IFileGenerator generator)
         {
-            throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
+            // throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
         }
 
         public void GeneratePostDefaultPropsImport(IVcxprojGenerationContext context, IFileGenerator generator)
         {
-            throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
+            // throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
         }
 
         public void GenerateProjectConfigurationGeneral(IVcxprojGenerationContext context, IFileGenerator generator)
         {
-            throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
+            // throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
         }
 
         public void GenerateProjectConfigurationGeneral2(IVcxprojGenerationContext context, IFileGenerator generator)
         {
-            throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
+            // throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
         }
 
         public void GenerateProjectConfigurationFastBuildMakeFile(IVcxprojGenerationContext context, IFileGenerator generator)
         {
-            throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
+            // throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
         }
 
         public void GenerateProjectConfigurationCustomMakeFile(IVcxprojGenerationContext context, IFileGenerator generator)
         {
-            throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
+            // throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
         }
 
         public void GenerateProjectPlatformImportSheet(IVcxprojGenerationContext context, IFileGenerator generator)
         {
-            throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
+            // throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
         }
 
         public void GeneratePlatformResourceFileList(IVcxprojGenerationContext context, IFileGenerator generator, Strings alreadyWrittenPriFiles, IList<Vcxproj.ProjectFile> resourceFiles, IList<Vcxproj.ProjectFile> imageResourceFiles)
         {
-            throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
+            // throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
         }
 
         public void GeneratePlatformReferences(IVcxprojGenerationContext context, IFileGenerator generator)
         {
-            throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
+            // throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
         }
 
         // type -> files

--- a/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Apple/BaseApplePlatform.cs
+++ b/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Apple/BaseApplePlatform.cs
@@ -1730,6 +1730,14 @@ namespace Sharpmake
   </PropertyGroup>
 ";
 
+        private const string _projectConfigurationsCustomMakefile =
+            @"  <PropertyGroup Condition=""'$(Configuration)|$(Platform)'=='[conf.Name]|[platformName]'"">
+    <NMakeBuildCommandLine>[conf.CustomBuildSettings.BuildCommand]</NMakeBuildCommandLine>
+    <NMakeReBuildCommandLine>[conf.CustomBuildSettings.RebuildCommand]</NMakeReBuildCommandLine>
+    <NMakeCleanCommandLine>[conf.CustomBuildSettings.CleanCommand]</NMakeCleanCommandLine>
+  </PropertyGroup>
+";
+
         public void GenerateProjectConfigurationGeneral2(IVcxprojGenerationContext context, IFileGenerator generator)
         {
             generator.Write(_projectConfigurationsGeneral2);
@@ -1742,7 +1750,7 @@ namespace Sharpmake
 
         public void GenerateProjectConfigurationCustomMakeFile(IVcxprojGenerationContext context, IFileGenerator generator)
         {
-            // throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
+            generator.Write(_projectConfigurationsCustomMakefile);
         }
 
         public void GenerateProjectPlatformImportSheet(IVcxprojGenerationContext context, IFileGenerator generator)

--- a/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Apple/BaseApplePlatform.cs
+++ b/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Apple/BaseApplePlatform.cs
@@ -575,6 +575,74 @@ namespace Sharpmake
         private static readonly Dictionary<string, IReadOnlyList<string>> s_clangSystemIncludeCache = new Dictionary<string, IReadOnlyList<string>>();
         private static readonly object s_clangSystemIncludeCacheLock = new object();
 
+        private static readonly Dictionary<string, IReadOnlyList<string>> s_clangBuiltinDefinesCache = new Dictionary<string, IReadOnlyList<string>>();
+        private static readonly object s_clangBuiltinDefinesCacheLock = new object();
+
+        // Returns "NAME=VALUE" strings for all non-function-like built-in macros reported by
+        //   clang++ -dM -E -x c++ /dev/null [-std=<stdFlag>] -isysroot <sdk-path>
+        private static IReadOnlyList<string> GetClangBuiltinDefinesForSdk(string sdkName, string stdFlag = null)
+        {
+            string cacheKey = string.IsNullOrEmpty(stdFlag) ? sdkName : $"{sdkName}|{stdFlag}";
+            lock (s_clangBuiltinDefinesCacheLock)
+            {
+                if (s_clangBuiltinDefinesCache.TryGetValue(cacheKey, out var cached))
+                    return cached;
+
+                var result = new List<string>();
+                try
+                {
+                    string sdkPath = RunProcessAndGetOutput("xcrun", $"--sdk {sdkName} --show-sdk-path").Trim();
+                    if (!string.IsNullOrEmpty(sdkPath))
+                    {
+                        string stdArg = string.IsNullOrEmpty(stdFlag) ? string.Empty : $"{stdFlag} ";
+                        string clangOutput = RunProcessAndGetOutput(
+                            "clang++",
+                            $"-dM -E -x c++ /dev/null {stdArg}-isysroot \"{sdkPath}\""
+                        );
+
+                        foreach (string line in clangOutput.Split('\n'))
+                        {
+                            string trimmed = line.Trim();
+                            if (!trimmed.StartsWith("#define ", StringComparison.Ordinal))
+                                continue;
+
+                            string rest = trimmed.Substring(8).Trim();
+                            int space = rest.IndexOf(' ');
+                            string name, value;
+                            if (space < 0)
+                            {
+                                name = rest;
+                                value = "1";
+                            }
+                            else
+                            {
+                                name = rest.Substring(0, space);
+                                value = rest.Substring(space + 1).Trim();
+                                if (value.Length == 0)
+                                    value = "1";
+                            }
+
+                            // Skip function-like macros: NAME(
+                            if (name.IndexOf('(') >= 0)
+                                continue;
+
+                            // Normalize whitespace in value
+                            value = System.Text.RegularExpressions.Regex.Replace(value, @"\s+", " ");
+                            result.Add($"{name}={value}");
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Trace.TraceWarning($"[Sharpmake] Could not discover built-in defines for SDK '{sdkName}': {ex.Message}");
+                }
+
+                IReadOnlyList<string> readOnly = result.AsReadOnly();
+                s_clangBuiltinDefinesCache[cacheKey] = readOnly;
+                return readOnly;
+            }
+        }
+
         private static IReadOnlyList<string> GetClangSystemIncludePathsForSdk(string sdkName)
         {
             lock (s_clangSystemIncludeCacheLock)
@@ -1565,7 +1633,27 @@ namespace Sharpmake
 
         public virtual void SelectPreprocessorDefinitionsVcxproj(IVcxprojGenerationContext context)
         {
-            // throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
+            var defines = new Strings();
+            defines.AddRange(context.Options.ExplicitDefines);
+            defines.AddRange(context.Configuration.Defines);
+
+            // Extract -DFOO defines from AdditionalCompilerOptions
+            foreach (string compilerOption in context.Configuration.AdditionalCompilerOptions)
+            {
+                if (compilerOption.StartsWith("-D", StringComparison.Ordinal))
+                    defines.Add(compilerOption.Substring(2));
+            }
+
+            // Determine the C++ language standard flag (e.g. "-std=c++17") to pass to clang++
+            // so that built-in defines like __cplusplus reflect the correct value.
+            context.CommandLineOptions.TryGetValue("CppLanguageStd", out string cppStdFlag);
+            if (string.IsNullOrEmpty(cppStdFlag) || cppStdFlag == FileGeneratorUtilities.RemoveLineTag)
+                cppStdFlag = null;
+
+            // Add built-in compiler defines (clang++ -dM -E [-std=<cppStd>] -x c++ /dev/null) for IntelliSense
+            defines.AddRange(GetClangBuiltinDefinesForSdk(XcrunSdkName, cppStdFlag));
+
+            context.Options["PreprocessorDefinitions"] = defines.JoinStrings(";");
         }
 
         public bool HasPrecomp(IGenerationContext context)
@@ -1635,7 +1723,10 @@ namespace Sharpmake
 
         private const string _projectConfigurationsGeneral2 =
             @"  <PropertyGroup Condition=""'$(Configuration)|$(Platform)'=='[conf.Name]|[platformName]'"">
+    <NMakePreprocessorDefinitions>[EscapeXML:options.PreprocessorDefinitions][EscapeXML:options.IntellisenseAdditionalDefines]</NMakePreprocessorDefinitions>
     <NMakeIncludeSearchPath>[options.NMakeIncludeSearchPath]</NMakeIncludeSearchPath>
+    <NMakeForcedIncludes>[options.ForcedIncludeFiles]</NMakeForcedIncludes>
+    <AdditionalOptions>[options.IntellisenseCommandLineOptions]</AdditionalOptions>
   </PropertyGroup>
 ";
 

--- a/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Apple/BaseApplePlatform.cs
+++ b/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Apple/BaseApplePlatform.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Sharpmake.Generators;
@@ -566,6 +567,100 @@ namespace Sharpmake
         public bool ExcludesPrecompiledHeadersFromBuild => false;
         public bool HasUserAccountControlSupport => false;
         public bool HasEditAndContinueDebuggingSupport => false;
+        public bool IsMSVC => false;
+
+        // The xcrun SDK name for this platform, e.g. "iphoneos", "macosx", "appletvos", "watchos"
+        protected abstract string XcrunSdkName { get; }
+
+        private static readonly Dictionary<string, IReadOnlyList<string>> s_clangSystemIncludeCache = new Dictionary<string, IReadOnlyList<string>>();
+        private static readonly object s_clangSystemIncludeCacheLock = new object();
+
+        private static IReadOnlyList<string> GetClangSystemIncludePathsForSdk(string sdkName)
+        {
+            lock (s_clangSystemIncludeCacheLock)
+            {
+                if (s_clangSystemIncludeCache.TryGetValue(sdkName, out var cached))
+                    return cached;
+
+                var result = new List<string>();
+                try
+                {
+                    // Get the SDK path via xcrun
+                    string sdkPath = RunProcessAndGetOutput("xcrun", $"--sdk {sdkName} --show-sdk-path").Trim();
+                    if (!string.IsNullOrEmpty(sdkPath))
+                    {
+                        // Run clang to get the system include paths
+                        string clangOutput = RunProcessAndGetOutput(
+                            "clang++",
+                            $"-v -E -x c++ /dev/null -isysroot \"{sdkPath}\"",
+                            redirectStdErr: true
+                        );
+
+                        bool inSearchList = false;
+                        foreach (string line in clangOutput.Split('\n'))
+                        {
+                            if (line.TrimEnd() == "#include <...> search starts here:")
+                            {
+                                inSearchList = true;
+                                continue;
+                            }
+                            if (line.TrimEnd() == "End of search list.")
+                            {
+                                inSearchList = false;
+                                continue;
+                            }
+                            if (inSearchList)
+                            {
+                                // Lines look like " /path/to/dir" or " /path/to/dir (framework directory)"
+                                string path = line.Trim();
+                                int parenIdx = path.IndexOf(" (", StringComparison.Ordinal);
+                                if (parenIdx >= 0)
+                                    path = path.Substring(0, parenIdx).TrimEnd();
+                                if (!string.IsNullOrEmpty(path))
+                                    result.Add(path);
+                            }
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    // If xcrun or clang++ is not available (e.g., not on macOS), return empty list
+                    Trace.TraceWarning($"[Sharpmake] Could not discover system include paths for SDK '{sdkName}': {ex.Message}");
+                }
+
+                IReadOnlyList<string> readOnly = result.AsReadOnly();
+                s_clangSystemIncludeCache[sdkName] = readOnly;
+                return readOnly;
+            }
+        }
+
+        private static string RunProcessAndGetOutput(string executable, string arguments, bool redirectStdErr = false)
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = executable,
+                Arguments = arguments,
+                RedirectStandardOutput = true,
+                RedirectStandardError = redirectStdErr,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            using (var process = Process.Start(psi))
+            {
+                if (process == null)
+                {
+                    Trace.TraceWarning($"[Sharpmake] Failed to start process: {executable} {arguments}");
+                    return string.Empty;
+                }
+
+                string output = process.StandardOutput.ReadToEnd();
+                string errOutput = redirectStdErr ? process.StandardError.ReadToEnd() : string.Empty;
+                process.WaitForExit();
+
+                return redirectStdErr ? output + errOutput : output;
+            }
+        }
 
         public IEnumerable<string> GetImplicitlyDefinedSymbols(IGenerationContext context)
         {
@@ -601,7 +696,8 @@ namespace Sharpmake
         }
         public IEnumerable<string> GetPlatformIncludePaths(IGenerationContext context)
         {
-            return GetPlatformIncludePathsWithPrefixImpl(context).Select(x => x.Path);
+            return GetPlatformIncludePathsWithPrefixImpl(context).Select(x => x.Path)
+                .Concat(GetClangSystemIncludePathsForSdk(XcrunSdkName));
         }
         public IEnumerable<IncludeWithPrefix> GetPlatformIncludePathsWithPrefix(IGenerationContext context)
         {
@@ -1537,9 +1633,15 @@ namespace Sharpmake
             // throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
         }
 
+        private const string _projectConfigurationsGeneral2 =
+            @"  <PropertyGroup Condition=""'$(Configuration)|$(Platform)'=='[conf.Name]|[platformName]'"">
+    <NMakeIncludeSearchPath>[options.NMakeIncludeSearchPath]</NMakeIncludeSearchPath>
+  </PropertyGroup>
+";
+
         public void GenerateProjectConfigurationGeneral2(IVcxprojGenerationContext context, IFileGenerator generator)
         {
-            // throw new NotImplementedException(SimplePlatformString + " should not be called by a Vcxproj generator");
+            generator.Write(_projectConfigurationsGeneral2);
         }
 
         public void GenerateProjectConfigurationFastBuildMakeFile(IVcxprojGenerationContext context, IFileGenerator generator)

--- a/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Apple/MacCatalystPlatform.cs
+++ b/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Apple/MacCatalystPlatform.cs
@@ -26,6 +26,8 @@ namespace Sharpmake
             public override string SimplePlatformString => "MacCatalyst"; // "Mac Catalyst" is the actual name
             #endregion
 
+            protected override string XcrunSdkName => "macosx";
+
             #region IPlatformBff implementation
             public override string BffPlatformDefine => "_MACCATALYST";
 

--- a/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Apple/MacOsPlatform.cs
+++ b/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Apple/MacOsPlatform.cs
@@ -25,6 +25,8 @@ namespace Sharpmake
             public override string SimplePlatformString => "macOS";
             #endregion
 
+            protected override string XcrunSdkName => "macosx";
+
             #region IPlatformBff implementation
             public override string BffPlatformDefine => "APPLE_OSX";
 

--- a/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Apple/iOsPlatform.cs
+++ b/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Apple/iOsPlatform.cs
@@ -26,6 +26,8 @@ namespace Sharpmake
             public override string SimplePlatformString => "iOS";
             #endregion
 
+            protected override string XcrunSdkName => "iphoneos";
+
             #region IPlatformBff implementation
             public override string BffPlatformDefine => "_IOS";
 

--- a/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Apple/tvOsPlatform.cs
+++ b/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Apple/tvOsPlatform.cs
@@ -25,6 +25,8 @@ namespace Sharpmake
             public override string SimplePlatformString => "tvOS";
             #endregion
 
+            protected override string XcrunSdkName => "appletvos";
+
             #region IPlatformBff implementation
             public override string BffPlatformDefine => "_TVOS";
 

--- a/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Apple/watchOsPlatform.cs
+++ b/Sharpmake.Platforms/Sharpmake.CommonPlatforms/Apple/watchOsPlatform.cs
@@ -25,6 +25,8 @@ namespace Sharpmake
             public override string SimplePlatformString => "watchOS";
             #endregion
 
+            protected override string XcrunSdkName => "watchos";
+
             #region IPlatformBff implementation
             public override string BffPlatformDefine => "_WATCHOS";
 

--- a/Sharpmake.Platforms/Sharpmake.CommonPlatforms/BasePlatform.cs
+++ b/Sharpmake.Platforms/Sharpmake.CommonPlatforms/BasePlatform.cs
@@ -138,6 +138,7 @@ namespace Sharpmake
         public virtual bool ExcludesPrecompiledHeadersFromBuild => false;
         public virtual bool HasUserAccountControlSupport => false;
         public virtual bool HasEditAndContinueDebuggingSupport => false;
+        public virtual bool IsMSVC => true;
 
         public virtual void SetupDeleteExtensionsOnCleanOptions(IGenerationContext context)
         {

--- a/samples/HelloXCode/HelloXCode.CommonProject.sharpmake.cs
+++ b/samples/HelloXCode/HelloXCode.CommonProject.sharpmake.cs
@@ -41,6 +41,8 @@ namespace HelloXCode
             conf.ProjectFileName = "[project.Name]_[target.Platform]";
             if (target.DevEnv != DevEnv.xcode)
                 conf.ProjectFileName += "_[target.DevEnv]";
+            if (target.BuildSystem == BuildSystem.FastBuild)
+                conf.ProjectFileName += "_FastBuild";
             conf.ProjectPath = Path.Combine(Globals.TmpDirectory, @"projects\[project.Name]");
             conf.IsFastBuild = target.BuildSystem == BuildSystem.FastBuild;
 
@@ -118,9 +120,6 @@ namespace HelloXCode
         {
             conf.FastBuildBlobbed = false;
             conf.IsBlobbed = false;
-
-            if (conf.IsFastBuild)
-                conf.ProjectName += "_NoBlob";
         }
         #endregion
         ////////////////////////////////////////////////////////////////////////

--- a/samples/HelloXCode/HelloXCode.CommonProject.sharpmake.cs
+++ b/samples/HelloXCode/HelloXCode.CommonProject.sharpmake.cs
@@ -71,6 +71,21 @@ namespace HelloXCode
             }
             else
                 conf.Options.Add(Sharpmake.Options.XCode.Compiler.DebugInformationFormat.Dwarf);
+
+            if (target.DevEnv != DevEnv.xcode && target.BuildSystem != BuildSystem.FastBuild)
+            {
+                // Provide NMake build/rebuild/clean commands so MSBuild can invoke xcodebuild
+                // for this project when opened via the generated vcxproj.
+                string xcodeProjectName = $"{Name}_{target.Platform}";
+                string xcodeProjectPath = Path.Combine(Globals.TmpDirectory, "projects", Name, xcodeProjectName + ".xcodeproj");
+                string xcodeConfiguration = target.Optimization.ToString(); // "Debug" or "Release"
+                conf.CustomBuildSettings = new Configuration.NMakeBuildSettings
+                {
+                    BuildCommand   = $"xcodebuild build   -project \"{xcodeProjectPath}\" -configuration {xcodeConfiguration}",
+                    RebuildCommand = $"xcodebuild clean build -project \"{xcodeProjectPath}\" -configuration {xcodeConfiguration}",
+                    CleanCommand   = $"xcodebuild clean   -project \"{xcodeProjectPath}\" -configuration {xcodeConfiguration}",
+                };
+            }
         }
 
         ////////////////////////////////////////////////////////////////////////

--- a/samples/HelloXCode/HelloXCode.CommonProject.sharpmake.cs
+++ b/samples/HelloXCode/HelloXCode.CommonProject.sharpmake.cs
@@ -76,14 +76,20 @@ namespace HelloXCode
             {
                 // Provide NMake build/rebuild/clean commands so MSBuild can invoke xcodebuild
                 // for this project when opened via the generated vcxproj.
-                string xcodeProjectName = $"{Name}_{target.Platform}";
-                string xcodeProjectPath = Path.Combine(Globals.TmpDirectory, "projects", Name, xcodeProjectName + ".xcodeproj");
-                string xcodeConfiguration = target.Optimization.ToString(); // "Debug" or "Release"
+                // The xcodeproj is generated in the same directory as the vcxproj, so we use
+                // $(MSBuildProjectDirectory) to resolve the correct path at build time.
+                string xcodeProjectName = $"{Name}_{Util.GetSimplePlatformString(target.Platform)}";
+                string xcodeProjectPath = $"$(MSBuildProjectDirectory)/{xcodeProjectName}.xcodeproj";
+                // XCode configurations are named after target.Name which uses ToLowerInvariant()
+                // (e.g. "debug", "release"), so we must match that casing here.
+                // ONLY_ACTIVE_ARCH=NO ensures all architectures are built so that
+                // dependent projects (e.g. pre-linked libs) are consistent across archs.
+                string xcodeConfiguration = target.Optimization.ToString().ToLowerInvariant();
                 conf.CustomBuildSettings = new Configuration.NMakeBuildSettings
                 {
-                    BuildCommand   = $"xcodebuild build   -project \"{xcodeProjectPath}\" -configuration {xcodeConfiguration}",
-                    RebuildCommand = $"xcodebuild clean build -project \"{xcodeProjectPath}\" -configuration {xcodeConfiguration}",
-                    CleanCommand   = $"xcodebuild clean   -project \"{xcodeProjectPath}\" -configuration {xcodeConfiguration}",
+                    BuildCommand   = $"xcodebuild build   -project \"{xcodeProjectPath}\" -configuration {xcodeConfiguration} ONLY_ACTIVE_ARCH=NO",
+                    RebuildCommand = $"xcodebuild clean build -project \"{xcodeProjectPath}\" -configuration {xcodeConfiguration} ONLY_ACTIVE_ARCH=NO",
+                    CleanCommand   = $"xcodebuild clean   -project \"{xcodeProjectPath}\" -configuration {xcodeConfiguration} ONLY_ACTIVE_ARCH=NO",
                 };
             }
         }

--- a/samples/HelloXCode/HelloXCode.CommonTarget.sharpmake.cs
+++ b/samples/HelloXCode/HelloXCode.CommonTarget.sharpmake.cs
@@ -57,21 +57,27 @@ namespace HelloXCode
                 nameParts.Add(Optimization.ToString().ToLowerInvariant());
                 if (BuildSystem == BuildSystem.FastBuild)
                     nameParts.Add(BuildSystem.ToString().ToLowerInvariant());
+                
+                if (Blob == Blob.Blob)
+                    nameParts.Add(Blob.ToString().ToLowerInvariant());
 
                 return string.Join("_", nameParts);
             }
         }
-
+        
         public string SolutionPlatformName
         {
             get
             {
                 var nameParts = new List<string>();
 
-                nameParts.Add(BuildSystem.ToString());
-
-                if (BuildSystem == BuildSystem.FastBuild && Blob == Blob.NoBlob)
-                    nameParts.Add(Blob.ToString());
+                if (BuildSystem == BuildSystem.FastBuild)
+                    nameParts.Add(BuildSystem.ToString().ToLowerInvariant());
+                
+                if (Blob == Blob.Blob)
+                    nameParts.Add(Blob.ToString().ToLowerInvariant());
+                
+                nameParts.Add(DevEnv.ToString().ToLowerInvariant());
 
                 return string.Join("_", nameParts);
             }
@@ -92,8 +98,7 @@ namespace HelloXCode
                 if (BuildSystem == BuildSystem.FastBuild)
                     dirNameParts.Add(BuildSystem.ToString());
 
-                if (DevEnv != DevEnv.xcode)
-                    dirNameParts.Add(DevEnv.ToString());
+                dirNameParts.Add(DevEnv.ToString());
 
                 return string.Join("_", dirNameParts).ToLowerInvariant();
             }
@@ -115,7 +120,7 @@ namespace HelloXCode
         {
             var macosTarget = new CommonTarget(
                 Platform.mac,
-                DevEnv.xcode,
+                DevEnv.xcode | DevEnv.vs2026,
                 Optimization.Debug | Optimization.Release,
                 Blob.NoBlob,
                 BuildSystem.Default
@@ -129,12 +134,13 @@ namespace HelloXCode
             // make a fastbuild version of the target
             var macosFastBuildTarget = (CommonTarget)macosTarget.Clone(
                 Blob.FastBuildUnitys,
-                BuildSystem.FastBuild
+                BuildSystem.FastBuild,
+                DevEnv.vs2026
             );
 
             var iosTarget = new CommonTarget(
                 Platform.ios,
-                DevEnv.xcode,
+                DevEnv.xcode | DevEnv.vs2026,
                 Optimization.Debug | Optimization.Release,
                 Blob.NoBlob,
                 BuildSystem.Default
@@ -148,12 +154,13 @@ namespace HelloXCode
             // make a fastbuild version of the target
             var iosFastBuildTarget = (CommonTarget)iosTarget.Clone(
                 Blob.FastBuildUnitys,
-                BuildSystem.FastBuild
+                BuildSystem.FastBuild,
+                DevEnv.vs2026
             );
 
             var tvosTarget = new CommonTarget(
                 Platform.tvos,
-                DevEnv.xcode,
+                DevEnv.xcode | DevEnv.vs2026,
                 Optimization.Debug | Optimization.Release,
                 Blob.NoBlob,
                 BuildSystem.Default
@@ -167,12 +174,13 @@ namespace HelloXCode
             // make a fastbuild version of the target
             var tvosFastBuildTarget = (CommonTarget)tvosTarget.Clone(
                 Blob.FastBuildUnitys,
-                BuildSystem.FastBuild
+                BuildSystem.FastBuild,
+                DevEnv.vs2026
             );
 
             var watchosTarget = new CommonTarget(
                 Platform.watchos,
-                DevEnv.xcode,
+                DevEnv.xcode | DevEnv.vs2026,
                 Optimization.Debug | Optimization.Release,
                 Blob.NoBlob,
                 BuildSystem.Default
@@ -186,12 +194,13 @@ namespace HelloXCode
             // make a fastbuild version of the target
             var watchosFastBuildTarget = (CommonTarget)watchosTarget.Clone(
                 Blob.FastBuildUnitys,
-                BuildSystem.FastBuild
+                BuildSystem.FastBuild,
+                DevEnv.vs2026
             );
 
             var catalystTarget = new CommonTarget(
                 Platform.maccatalyst,
-                DevEnv.xcode,
+                DevEnv.xcode | DevEnv.vs2026,
                 Optimization.Debug | Optimization.Release,
                 Blob.NoBlob,
                 BuildSystem.Default
@@ -205,7 +214,8 @@ namespace HelloXCode
             // make a FastBuild version of the target
             var catalystFastBuildTarget = (CommonTarget)catalystTarget.Clone(
                 Blob.FastBuildUnitys,
-                BuildSystem.FastBuild
+                BuildSystem.FastBuild,
+                DevEnv.vs2026
             );
 
             return new[] {

--- a/samples/HelloXCode/codebase/static_prelinked_lib_consumer/static_prelinked_lib1.sharpmake.cs
+++ b/samples/HelloXCode/codebase/static_prelinked_lib_consumer/static_prelinked_lib1.sharpmake.cs
@@ -30,20 +30,29 @@ namespace HelloXCode
 
             conf.IncludePaths.Add(SourceRootPath);
 
-            //  Important! do not link the Consumed library - let it be pre-linked by XCode
-            conf.AddPrivateDependency<StaticPrelinkedLibConsumed>(target, DependencySetting.DefaultWithoutLinking);
+            if (target.BuildSystem == BuildSystem.FastBuild)
+            {
+                // FastBuild does not support XCode pre-linking options, so link the consumed
+                // library normally so all symbols are available at link time.
+                conf.AddPrivateDependency<StaticPrelinkedLibConsumed>(target);
+            }
+            else
+            {
+                //  Important! do not link the Consumed library - let it be pre-linked by XCode
+                conf.AddPrivateDependency<StaticPrelinkedLibConsumed>(target, DependencySetting.DefaultWithoutLinking);
 
-            //  Custom build step - to generate the sub library
-            var platform = Util.GetSimplePlatformString(target.GetPlatform());
-            var projPath = Path.Combine(Globals.TmpDirectory, "projects/static_prelinked_lib_consumed");
-            var configuration = target.Optimization.ToString().ToLowerInvariant();
-            conf.EventPreBuild.Add($"xcodebuild build -scheme static_prelinked_lib_consumed_{platform} -project {projPath}/static_prelinked_lib_consumed_{platform}.xcodeproj -configuration {configuration}");
+                //  Custom build step - to generate the sub library
+                var platform = Util.GetSimplePlatformString(target.GetPlatform());
+                var projPath = Path.Combine(Globals.TmpDirectory, "projects/static_prelinked_lib_consumed");
+                var configuration = target.Optimization.ToString().ToLowerInvariant();
+                conf.EventPreBuild.Add($"xcodebuild build ONLY_ACTIVE_ARCH=NO -scheme static_prelinked_lib_consumed_{platform} -project {projPath}/static_prelinked_lib_consumed_{platform}.xcodeproj -configuration {configuration}");
 
-            //  Test pre-linked libraries
-            var libraryToPrelink = Path.Combine(conf.TargetLibraryPath, "..", "static_prelinked_lib_consumed", "libstatic_prelinked_lib_consumed.a");
+                //  Test pre-linked libraries
+                var libraryToPrelink = Path.Combine(conf.TargetLibraryPath, "..", "static_prelinked_lib_consumed", "libstatic_prelinked_lib_consumed.a");
 
-            conf.Options.Add(Options.XCode.Linker.PerformSingleObjectPrelink.Enable);
-            conf.Options.Add(new Options.XCode.Linker.PrelinkLibraries(libraryToPrelink));
+                conf.Options.Add(Options.XCode.Linker.PerformSingleObjectPrelink.Enable);
+                conf.Options.Add(new Options.XCode.Linker.PrelinkLibraries(libraryToPrelink));
+            }
         }
     }
 }


### PR DESCRIPTION
This fixes Mac part of https://github.com/ubisoft/Sharpmake/issues/453

I targetted HelloXCode sample, with sln, vcxproj, regular xcode build and fastbuild.

I have Build/Rebuild/Clean working, and all the code resolved except one case which requires changes in Rider itself.

Specifically support for System Frameworks like CoreFoundation. Made a ticket for myself in the JetBrains bugtracker https://youtrack.jetbrains.com/issue/RIDER-137325/Mac-Support-System-Frameworks-like-CoreFoundation