### PR TITLE
Add CppWinRT_IncludePath to GetWindowsIncludePath method output

### DIFF
--- a/Sharpmake/ExtensionMethods.cs
+++ b/Sharpmake/ExtensionMethods.cs
@@ -623,10 +623,11 @@ namespace Sharpmake
                         string platformVersion = windowsTargetPlatformVersion.ToVersionString();
                         var paths = new List<string> {
                             $@"{visualStudioInclude}",
-                            $@"{kitsRoot10}Include\{platformVersion}\um",     // $(UM_IncludePath)
-                            $@"{kitsRoot10}Include\{platformVersion}\shared", // $(KIT_SHARED_IncludePath)
-                            $@"{kitsRoot10}Include\{platformVersion}\winrt",  // $(WinRT_IncludePath)
-                            $@"{kitsRoot10}Include\{platformVersion}\ucrt",   // $(UniversalCRT_IncludePath)
+                            $@"{kitsRoot10}Include\{platformVersion}\um",        // $(UM_IncludePath)
+                            $@"{kitsRoot10}Include\{platformVersion}\shared",    // $(KIT_SHARED_IncludePath)
+                            $@"{kitsRoot10}Include\{platformVersion}\winrt",     // $(WinRT_IncludePath)
+                            $@"{kitsRoot10}Include\{platformVersion}\cppwinrt",  // $(CppWinRT_IncludePath)
+                            $@"{kitsRoot10}Include\{platformVersion}\ucrt",      // $(UniversalCRT_IncludePath)
                         };
 
                         if (windowsTargetPlatformVersion <= Options.Vc.General.WindowsTargetPlatformVersion.v10_0_10240_0)


### PR DESCRIPTION
`WinRT_IncludePath` is already mentioned there but it is not enough.

Caught this bug when trying to build a C++ project including `<winrt/Windows.Devices.Midi.h>` with FastBuild.